### PR TITLE
Sort date_updated desc and move sort selector

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -134,7 +134,9 @@ export default ApplicationController.extend({
             from: (page - 1) * this.get('size')
         };
         if (this.get('sort')) {
-            queryBody.sort = this.get('sort');
+            let sortBy = {};
+            sortBy[this.get('sort')] = 'desc';
+            queryBody.sort = sortBy;
         }
         if (page === 1) {
             queryBody.aggregations = this.get('elasticAggregations');

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -56,14 +56,19 @@
             </div>
         </div>
     {{/bs-collapse}}
-    <hr>
     <div class="row">
-        <div class='col-xs-3'>
+        <div class="col-xs-2 col-xs-offset-10" style="text-align: right">
             <select onchange={{action 'selectSortOption' value="target.value"}}>
                 {{#each sortOptions as |sortChoice|}}
                     <option value={{sortChoice.sortBy}} selected={{eq sort sortChoice.sortBy}}>{{sortChoice.display}}</option>
                 {{/each}}
             </select>
+        </div>
+    </div>
+    <hr>
+    <div class="row">
+        <div class='col-xs-3'>
+
             <button {{action 'clearFilters'}} class='btn btn-default'>
                 Clear filters
             </button>


### PR DESCRIPTION
Related to #15 

* sort date_updated desc instead of the default
* move sort selector to above divider

![screen shot 2016-08-09 at 4 17 10 pm](https://cloud.githubusercontent.com/assets/7131985/17532059/c626c6fa-5e4c-11e6-8019-3b894ee425c1.png)


