### PR TITLE
[Feature] Paginated related works and search results

### DIFF
--- a/app/components/link-to-work/component.js
+++ b/app/components/link-to-work/component.js
@@ -2,10 +2,10 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
     tagName: 'span',
-    prettyType: Ember.computed('work.type', function() {
-        return this.get('work.type').split(/([A-Z][a-z]+)/).filter(x => x).join(' ');
-    }),
     slugType: Ember.computed('work.type', function() {
         return this.get('work.type').classify().toLowerCase();
-    })
+    }),
+    title: Ember.computed('work.title', function() {
+        return this.get('work.title') || '(Untitled)';
+    }),
 });

--- a/app/components/link-to-work/template.hbs
+++ b/app/components/link-to-work/template.hbs
@@ -1,5 +1,5 @@
-<span style="color: #888">[{{prettyType}}]</span>&nbsp;
+<span style="color: #888">[{{prettify work.type}}]</span>&nbsp;
 {{~#link-to 'detail' slugType work.id~}}
-{{work.title}}
+{{title}}
 {{~/link-to~}}
 

--- a/app/components/page-controls/component.js
+++ b/app/components/page-controls/component.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    page: Ember.computed('offset', 'pageSize', function() {
+        return 1 + Math.floor(this.get('offset') / this.get('pageSize'));
+    }),
+
+    totalPages: Ember.computed('pageSize', 'total', function() {
+        return Math.ceil(this.get('total') / this.get('pageSize'));
+    }),
+
+    atFirstPage: Ember.computed.equal('page', 1),
+
+    atLastPage: Ember.computed('page', 'totalPages', function() {
+        return this.get('page') === this.get('totalPages');
+    }),
+
+    actions: {
+        previousPage: function() {
+            const previousOffset = (this.get('page') - 2) * this.get('pageSize');
+            this.get('getPage')(previousOffset);
+        },
+
+        nextPage: function() {
+            const nextOffset = this.get('page') * this.get('pageSize');
+            this.get('getPage')(nextOffset);
+        }
+    }
+});

--- a/app/components/page-controls/component.js
+++ b/app/components/page-controls/component.js
@@ -1,14 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-    page: Ember.computed('offset', 'pageSize', function() {
-        return 1 + Math.floor(this.get('offset') / this.get('pageSize'));
-    }),
-
-    totalPages: Ember.computed('pageSize', 'total', function() {
-        return Math.ceil(this.get('total') / this.get('pageSize'));
-    }),
-
     atFirstPage: Ember.computed.equal('page', 1),
 
     atLastPage: Ember.computed('page', 'totalPages', function() {
@@ -16,14 +8,12 @@ export default Ember.Component.extend({
     }),
 
     actions: {
-        previousPage: function() {
-            const previousOffset = (this.get('page') - 2) * this.get('pageSize');
-            this.get('getPage')(previousOffset);
+        prevPage: function() {
+            this.get('prevPage')();
         },
 
         nextPage: function() {
-            const nextOffset = this.get('page') * this.get('pageSize');
-            this.get('getPage')(nextOffset);
+            this.get('nextPage')();
         }
     }
 });

--- a/app/components/page-controls/component.js
+++ b/app/components/page-controls/component.js
@@ -7,13 +7,37 @@ export default Ember.Component.extend({
         return this.get('page') === this.get('totalPages');
     }),
 
+    pageLinks: Ember.computed('page', 'totalPages', function() {
+        const radius = 2;
+        const page = this.get('page');
+        const total = this.get('totalPages');
+        const pages = [1];
+        if (page > radius + 2) {
+            pages.push(null);
+        }
+        for (let i = Math.max(page - radius, 2); i <= Math.min(page + radius, total); i++) {
+            pages.push(i);
+        }
+        if (page + radius + 1 < total) {
+            pages.push(null);
+        }
+        if (page + radius < total) {
+            pages.push(total);
+        }
+        return pages;
+    }),
+
     actions: {
-        prevPage: function() {
-            this.get('prevPage')();
+        loadPage(page) {
+            this.get('loadPage')(page);
         },
 
-        nextPage: function() {
-            this.get('nextPage')();
+        prevPage() {
+            this.get('loadPage')(this.get('page') - 1);
+        },
+
+        nextPage() {
+            this.get('loadPage')(this.get('page') + 1);
         }
     }
 });

--- a/app/components/page-controls/template.hbs
+++ b/app/components/page-controls/template.hbs
@@ -1,4 +1,4 @@
-<button class="btn btn-sm btn-default" disabled={{atFirstPage}} title='Previous Page' {{action 'previousPage'}}>
+<button class="btn btn-sm btn-default" disabled={{atFirstPage}} title='Previous Page' {{action 'prevPage'}}>
     <i class="fa fa-angle-left"></i>
     Previous
 </button>

--- a/app/components/page-controls/template.hbs
+++ b/app/components/page-controls/template.hbs
@@ -1,0 +1,9 @@
+<button class="btn btn-sm btn-default" disabled={{atFirstPage}} title='Previous Page' {{action 'previousPage'}}>
+    <i class="fa fa-angle-left"></i>
+    Previous
+</button>
+<span>Page {{page}} of {{totalPages}}</span>
+<button class="btn btn-sm btn-default" disabled={{atLastPage}} title='Next Page' {{action 'nextPage'}}>
+    Next
+    <i class="fa fa-angle-right"></i>
+</button>

--- a/app/components/page-controls/template.hbs
+++ b/app/components/page-controls/template.hbs
@@ -1,9 +1,17 @@
-<button class="btn btn-sm btn-default" disabled={{atFirstPage}} title='Previous Page' {{action 'prevPage'}}>
+<button class="btn btn-xs btn-default" disabled={{atFirstPage}} title='Previous Page' {{action 'prevPage'}}>
     <i class="fa fa-angle-left"></i>
-    Previous
 </button>
-<span>Page {{page}} of {{totalPages}}</span>
-<button class="btn btn-sm btn-default" disabled={{atLastPage}} title='Next Page' {{action 'nextPage'}}>
-    Next
+{{#each pageLinks as |pageNum|}}
+    {{#if pageNum}}
+        {{#if (eq page pageNum)}}
+            <span style='font-weight: bold; margin: 0 0.3em;'>{{pageNum}}</span>
+        {{else}}
+            <a href='#' style='margin: 0 0.3em' {{action 'loadPage' pageNum}}>{{pageNum}}</a>
+        {{/if}}
+    {{else}}
+        <i class="fa fa-fw fa-ellipsis-h"></i>
+    {{/if}}
+{{/each}}
+<button class="btn btn-xs btn-default" disabled={{atLastPage}} title='Next Page' {{action 'nextPage'}}>
     <i class="fa fa-angle-right"></i>
 </button>

--- a/app/components/section-related-works/component.js
+++ b/app/components/section-related-works/component.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-//import page_query from '../../utils/graphql';
 import { PAGE_FRAGMENT_MAP } from '../../utils/mappings';
 
 export default Ember.Component.extend({
@@ -48,9 +47,9 @@ export default Ember.Component.extend({
             }).then(data => {
                 if (data.errors) {throw Error(data.errors[0].message);}
                 this.setProperties({
-                    'loadingPage': false,
+                    loadingPage: false,
                     'model.relatedWorks': data.data.shareObject.relatedWorks,
-                    'offset': newOffset
+                    offset: newOffset
                 });
             });
         },

--- a/app/components/section-related-works/component.js
+++ b/app/components/section-related-works/component.js
@@ -8,15 +8,34 @@ export default Ember.Component.extend({
     offset: 0,
     pageSize: 10,
 
-    showPageControls: Ember.computed('model.totalRelatedWorks', 'pageSize', function() {
-        return this.get('model.totalRelatedWorks') > this.get('pageSize');
+    page: Ember.computed('offset', 'pageSize', function() {
+        return 1 + Math.floor(this.get('offset') / this.get('pageSize'));
     }),
 
+    totalPages: Ember.computed('pageSize', 'model.totalRelatedWorks', function() {
+        return Math.ceil(this.get('model.totalRelatedWorks') / this.get('pageSize'));
+    }),
+
+    showPageControls: Ember.computed.gt('totalPages', 1),
+
     actions: {
+        nextPage: function() {
+            const nextOffset = this.get('page') * this.get('pageSize');
+            this.send('getPage', nextOffset);
+        },
+
+        prevPage: function() {
+            const prevOffset = (this.get('page') - 2) * this.get('pageSize');
+            this.send('getPage', prevOffset);
+        },
+
         getPage: function(newOffset) {
+            if (this.get('loadingPage')) {return;}
+            this.set('loadingPage', true);
+
             const model = this.get('model');
             const adapter = this.get('store').adapterFor('application');
-            // TODO consolidate graphql queries in utils or a service or something
+            // TODO consolidate graphql queries in a util or service or something
             adapter.ajax('/api/v2/graph/', 'POST', {
                 data: {
                     variables: '',
@@ -27,12 +46,13 @@ export default Ember.Component.extend({
                     }`
                 }
             }).then(data => {
-                if (data.errors) throw Error(data.errors[0].message);
+                if (data.errors) {throw Error(data.errors[0].message);}
                 this.setProperties({
+                    'loadingPage': false,
                     'model.relatedWorks': data.data.shareObject.relatedWorks,
                     'offset': newOffset
                 });
             });
-        }
+        },
     }
 });

--- a/app/components/section-related-works/component.js
+++ b/app/components/section-related-works/component.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+//import page_query from '../../utils/graphql';
+import { PAGE_FRAGMENT_MAP } from '../../utils/mappings';
+
+export default Ember.Component.extend({
+    store: Ember.inject.service(),
+
+    offset: 0,
+    pageSize: 10,
+
+    showPageControls: Ember.computed('model.totalRelatedWorks', 'pageSize', function() {
+        return this.get('model.totalRelatedWorks') > this.get('pageSize');
+    }),
+
+    actions: {
+        getPage: function(newOffset) {
+            const model = this.get('model');
+            const adapter = this.get('store').adapterFor('application');
+            // TODO consolidate graphql queries in utils or a service or something
+            adapter.ajax('/api/v2/graph/', 'POST', {
+                data: {
+                    variables: '',
+                    query: `query {
+                        shareObject(id: "${model.id}") {
+                            ${Object.entries(PAGE_FRAGMENT_MAP).map(([type, fragments]) => `...on ${type} { ${fragments.relatedWorks(newOffset)} }`).join('\n')}
+                        }
+                    }`
+                }
+            }).then(data => {
+                if (data.errors) throw Error(data.errors[0].message);
+                this.setProperties({
+                    'model.relatedWorks': data.data.shareObject.relatedWorks,
+                    'offset': newOffset
+                });
+            });
+        }
+    }
+});

--- a/app/components/section-related-works/template.hbs
+++ b/app/components/section-related-works/template.hbs
@@ -1,5 +1,6 @@
 <ul>
-  {{#each model.relatedWorks as |relation index|}}
-    <li>{{link-to-work work=relation.creativeWork}}</li>
-  {{/each}}
+    {{#each model.relatedWorks as |relation index|}}
+        <li>{{relation.type}}: {{link-to-work work=relation.creativeWork}}</li>
+    {{/each}}
 </ul>
+{{page-controls list='relatedWorks' model=model start=0 end=10 total=model.totalRelatedWorks}} 

--- a/app/components/section-related-works/template.hbs
+++ b/app/components/section-related-works/template.hbs
@@ -1,6 +1,6 @@
 {{#if showPageControls}}
     <div class='text-center'>
-        {{page-controls offset=offset pageSize=pageSize total=model.totalRelatedWorks getPage=(action 'getPage')}} 
+        {{page-controls page=page totalPages=totalPages nextPage=(action 'nextPage') prevPage=(action 'prevPage')}} 
     </div>
 {{/if}}
 <ul>

--- a/app/components/section-related-works/template.hbs
+++ b/app/components/section-related-works/template.hbs
@@ -1,6 +1,10 @@
+{{#if showPageControls}}
+    <div class='text-center'>
+        {{page-controls offset=offset pageSize=pageSize total=model.totalRelatedWorks getPage=(action 'getPage')}} 
+    </div>
+{{/if}}
 <ul>
     {{#each model.relatedWorks as |relation index|}}
         <li>{{relation.type}}: {{link-to-work work=relation.creativeWork}}</li>
     {{/each}}
 </ul>
-{{page-controls list='relatedWorks' model=model start=0 end=10 total=model.totalRelatedWorks}} 

--- a/app/components/section-related-works/template.hbs
+++ b/app/components/section-related-works/template.hbs
@@ -4,7 +4,7 @@
     </div>
 {{/if}}
 <ul>
-    {{#each model.relatedWorks as |relation index|}}
-        <li>{{relation.type}}: {{link-to-work work=relation.creativeWork}}</li>
+    {{#each data as |relation index|}}
+        <li>{{prettify relation.type}}: {{link-to-work work=relation.creativeWork}}</li>
     {{/each}}
 </ul>

--- a/app/components/section-related-works/template.hbs
+++ b/app/components/section-related-works/template.hbs
@@ -1,6 +1,6 @@
 {{#if showPageControls}}
     <div class='text-center'>
-        {{page-controls page=page totalPages=totalPages nextPage=(action 'nextPage') prevPage=(action 'prevPage')}} 
+        {{page-controls page=page totalPages=totalPages loadPage=(action 'loadPage')}}
     </div>
 {{/if}}
 <ul>

--- a/app/components/section-work-related-works/template.hbs
+++ b/app/components/section-work-related-works/template.hbs
@@ -1,0 +1,9 @@
+<ul>
+    {{#each data as |relation index|}}
+        {{#if relation.subject}}
+            <li>{{link-to-work work=relation.subject}} {{prettify relation.type}} This Work</li>
+        {{else}}
+            <li>This Work {{prettify relation.type}} {{link-to-work work=relation.related}}</li>
+        {{/if}}
+    {{/each}}
+</ul>

--- a/app/controllers/agent.js
+++ b/app/controllers/agent.js
@@ -4,6 +4,7 @@ import DetailMixin from '../mixins/detail';
 const SECTIONS = [
     { title: 'Profiles', value: 'links', component: 'section-links' },
     { title: 'Events', value: 'model.relatedWorks', component: 'section-related-works' },
+    { title: 'Affiliations', value: 'model.relatedAgents', component: 'section-related-agents' },
     { title: 'Collected From', value: 'model.sources', component: 'section-sources' },
 ];
 

--- a/app/controllers/agent.js
+++ b/app/controllers/agent.js
@@ -3,7 +3,7 @@ import DetailMixin from '../mixins/detail';
 
 const SECTIONS = [
     { title: 'Profiles', value: 'links', component: 'section-links' },
-    { title: 'Worked on', value: 'model.relatedWorks', component: 'section-related-works' },
+    { title: 'Events', value: 'model.relatedWorks', component: 'section-related-works' },
     { title: 'Collected From', value: 'model.sources', component: 'section-sources' },
 ];
 

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -146,7 +146,7 @@ export default ApplicationController.extend({
             sortBy[this.get('sort').replace(/^-/, '')] = this.get('sort')[0] === '-' ? 'desc' : 'asc';
             queryBody.sort = sortBy;
         }
-        if (page === 1) {
+        if (page === 1 || this.get('firstLoad')) {
             queryBody.aggregations = this.get('elasticAggregations');
         }
 
@@ -194,6 +194,9 @@ export default ApplicationController.extend({
                 firstLoad: false,
                 results: results,
             });
+            if (results.length === 0 && this.get('totalPages') < this.get('page')) {
+                this.search()
+            }
         });
     },
 

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -258,7 +258,7 @@ export default ApplicationController.extend({
 
         addFilter(type, filterValue) {
             const category = this.get('category');
-            const action = 'remove-filter';
+            const action = 'add-filter';
             const label = filterValue;
 
             this.get('metrics').trackEvent({ category, action, label });
@@ -270,7 +270,7 @@ export default ApplicationController.extend({
 
         removeFilter(type, filterValue) {
             const category = this.get('category');
-            const action = 'add-filter';
+            const action = 'remove-filter';
             const label = filterValue;
 
             this.get('metrics').trackEvent({ category, action, label });
@@ -326,28 +326,18 @@ export default ApplicationController.extend({
             this.search();
         },
 
-        next() {
-            if (this.get('page') >= this.get('totalPages')) {
+        loadPage(newPage) {
+            if (newPage === this.get('page') || newPage < 1 || newPage > this.get('totalPages')) {
                 return;
             }
 
             const category = this.get('category');
-            const action = 'results';
-            const label = 'more-results';
+            const action = 'load-result-page';
+            const label = newPage;
 
             this.get('metrics').trackEvent({ category, action, label });
 
-            this.incrementProperty('page', 1);
-            this.scrollToResults();
-            this.loadPage();
-        },
-
-        prev() {
-            // No negative pages
-            if (this.get('page') <= 1) {
-                return;
-            }
-            this.decrementProperty('page', 1);
+            this.set('page', newPage);
             this.scrollToResults();
             this.loadPage();
         },

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -195,7 +195,7 @@ export default ApplicationController.extend({
                 results: results,
             });
             if (results.length === 0 && this.get('totalPages') < this.get('page')) {
-                this.search()
+                this.search();
             }
         });
     },

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -194,7 +194,7 @@ export default ApplicationController.extend({
                 firstLoad: false,
                 results: results,
             });
-            if (results.length === 0 && this.get('totalPages') < this.get('page')) {
+            if (this.get('totalPages') && this.get('totalPages') < this.get('page')) {
                 this.search();
             }
         });

--- a/app/controllers/work.js
+++ b/app/controllers/work.js
@@ -6,7 +6,8 @@ const SECTIONS = [
     { title: 'Contributors', value: 'contributors', component: 'section-related-agents' },
     { title: 'Published By', value: 'publishers', component: 'section-related-agents' },
     { title: 'Tags', value: 'model.tags', component: 'section-tags' },
-    { title: 'See Also', value: 'links', component: 'section-links' },
+    { title: 'External Links', value: 'links', component: 'section-links' },
+    { title: 'Related Works', value: 'relatedWorks', component: 'section-work-related-works' },
     { title: 'Collected From', value: 'model.sources', component: 'section-sources' },
 ];
 
@@ -19,5 +20,11 @@ export default Ember.Controller.extend(DetailMixin, {
 
     publishers: Ember.computed('model.relatedAgents', function() {
         return this.get('model.relatedAgents').filter(relation => RELATION_MAP[relation.type] === 'publisher');
+    }),
+
+    relatedWorks: Ember.computed('model.incomingWorkRelations', 'model.outgoingWorkRelations', function() {
+        const incoming = this.get('model.incomingWorkRelations') || [];
+        const outgoing = this.get('model.outgoingWorkRelations') || [];
+        return incoming.concat(outgoing);
     }),
 });

--- a/app/helpers/eq.js
+++ b/app/helpers/eq.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function eq([left, right]) {
+  return left === right;
+}
+
+export default Ember.Helper.helper(eq);

--- a/app/helpers/prettify.js
+++ b/app/helpers/prettify.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function prettify([str]) {
+    return str.split(/([A-Z][a-z]+)/).filter(x => x).join(' ');
+}
+
+export default Ember.Helper.helper(prettify);

--- a/app/mixins/detail.js
+++ b/app/mixins/detail.js
@@ -20,8 +20,8 @@ export default Ember.Mixin.create({
     // Links that people could actual click on and not get XML/JSON/etc
     links: Ember.computed('model.identifiers', function() {
         return this.get('model.identifiers').filter(identifier =>
-            Object.entries(VISITABLE).reduce((acc, [k, re]) => acc || re.test(identifier[k]), false)
-            && !Object.entries(AVOID).reduce((acc, [k, re]) => acc || re.test(identifier[k]), false)
+            Object.entries(VISITABLE).reduce((acc, [k, re]) => acc || re.test(identifier[k]), false) &&
+            !Object.entries(AVOID).reduce((acc, [k, re]) => acc || re.test(identifier[k]), false)
         );
     }),
 

--- a/app/routes/detail.js
+++ b/app/routes/detail.js
@@ -20,35 +20,47 @@ export default Ember.Route.extend({
               }`
             }
         }).then(data => {
-            if (data.errors) throw Error(data.errors[0].message);
+            if (data.errors) {
+                throw Error(data.errors[0].message);
+            }
             return data.data.shareObject;
         });
     },
     actions: {
-        error(error, transition) {
+        error(error) {
             console.error(error);
             return this.intermediateTransitionTo('notfound');
         }
     },
     setup(model, transition) {
-        if (!model) return this._super(model, transition);  // If the model could not be loaded. Do nothing.
+        if (!model) {
+            // If the model could not be loaded. Do nothing.
+            return this._super(model, transition);
+        }
 
         // Find the most specific template available for the found type
         let view = null;
-        for (let i = 0; i < model.types.length; i++)
-          if ((view = CONTROLLER_MAP[model.types[i]])) break;
+        for (let i = 0; i < model.types.length; i++) {
+            if ((view = CONTROLLER_MAP[model.types[i]])) {
+                break;
+            }
+        }
 
         this.set('templateName', view);
         this.set('controllerName', view);
         return this._super(model, transition);
     },
     afterModel(model, transition) {
-        if (!model) return;  // If the model could not be loaded. Do nothing.
+        if (!model) {
+            // If the model could not be loaded. Do nothing.
+            return;
+        }
 
         // If the type slug /:SLUG/:SHARE-ID is not the type of the object
         // Correct the url
         let slug = model.type.classify().toLowerCase();
-        if (slug !== transition.params.detail.type)
+        if (slug !== transition.params.detail.type) {
             return this.transitionTo('detail', slug, model.id);
+        }
     }
 });

--- a/app/templates/agent.hbs
+++ b/app/templates/agent.hbs
@@ -1,48 +1,50 @@
 {{title model.name}}
 
 <div class="title-container">
-  <div class="container">
-    <div class="jumbotron">
-      <h1 class="title">
-        {{#if avatar}}
-          <img class="img-circle" src={{avatar.uri}} style="margin-right: 5px; height: 80px;">
-        {{/if}}
-        {{model.name}}
-        <br>
-        <small>{{model.type}}</small>
-      </h1>
+    <div class="container">
+        <div class="jumbotron">
+            <h1 class="title">
+                {{#if avatar}}
+                    <img class="img-circle" src={{avatar.uri}} style="margin-right: 5px; height: 80px;">
+                {{/if}}
+                {{model.name}}
+                <br>
+                <small>{{model.type}}</small>
+            </h1>
+        </div>
     </div>
-  </div>
 </div>
 
 <div class="container">
-  <br>
-
-  {{#each sections as |section|}}
-    {{#if (get this section.value)}}
-      <br>
-      <h3>{{section.title}}</h3>
-      <hr style="margin-top: 0px; margin-bottom: 10px">
-      {{component section.component model=model data=(get this section.value)}}
-    {{/if}}
-  {{/each}}
-
-  {{#if hasExtra}}
     <br>
-    <h3>Additional Information
-      <small>
-        <a {{action 'toggleExtra'}} href="#">
-          {{#if showExtra}}
-            <i class="fa fa-caret-down"></i>
-          {{else}}
-            <i class="fa fa-caret-left"></i>
-          {{/if}}
-        </a>
-      </small>
-    </h3>
-    <hr style="margin-top: 0px; margin-bottom: 10px">
-    {{#if showExtra}}
-      {{json-pretty obj=model.extra shouldHighlight=true}}
+
+    {{#each sections as |section|}}
+        {{#if (get this section.value)}}
+            <div class='row'>
+                <br>
+                <h3>{{section.title}}</h3>
+                <hr style="margin-top: 0px; margin-bottom: 10px">
+                {{component section.component model=model data=(get this section.value)}}
+            </div>
+        {{/if}}
+    {{/each}}
+
+    {{#if hasExtra}}
+        <br>
+        <h3>Additional Information
+            <small>
+                <a {{action 'toggleExtra'}} href="#">
+                    {{#if showExtra}}
+                        <i class="fa fa-caret-down"></i>
+                    {{else}}
+                        <i class="fa fa-caret-left"></i>
+                    {{/if}}
+                </a>
+            </small>
+        </h3>
+        <hr style="margin-top: 0px; margin-bottom: 10px">
+        {{#if showExtra}}
+            {{json-pretty obj=model.extra shouldHighlight=true}}
+        {{/if}}
     {{/if}}
-  {{/if}}
 </div>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -133,11 +133,12 @@
             {{#if loading}}
                 {{loading-bars}}
             {{else if noResultsMessage}}
-                <div class="no-results">{{noResultsMessage}}</div>
+                <div class="text-center no-results">{{noResultsMessage}}</div>
             {{else}}
                 <div class="text-center">
                     {{page-controls page=page totalPages=totalPages loadPage=(action 'loadPage')}}
                 </div>
+                <hr>
                 {{#each results as |obj|}}
                     {{search-result addFilter='addFilter' obj=obj}}
                 {{/each}}

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -101,7 +101,7 @@
             </i>
         </div>
     </div>
-    <hr>
+    <hr class='results-top'>
     <div class="row">
         {{#if media.isExtraSmall}}
             <div class='col-xs-12 visible-xs'>
@@ -130,18 +130,18 @@
             </div>
         {{/if}}
         <div class='col-sm-9 col-xs-12'>
-            {{#each results as |obj|}}
-                {{search-result addFilter='addFilter' obj=obj}}
-            {{/each}}
-            <div class="text-center">
-                {{#if loading}}
-                  {{loading-bars}}
-                {{else if noResultsMessage}}
-                    <div class="no-results">{{noResultsMessage}}</div>
-                {{else if morePages}}
-                    <button class="btn btn-default" {{action 'next'}}> More </button>
-                {{/if}}
-            </div>
+            {{#if loading}}
+                {{loading-bars}}
+            {{else if noResultsMessage}}
+                <div class="no-results">{{noResultsMessage}}</div>
+            {{else}}
+                {{#each results as |obj|}}
+                    {{search-result addFilter='addFilter' obj=obj}}
+                {{/each}}
+                <div class="text-center">
+                    {{page-controls page=page totalPages=totalPages nextPage=(action 'next') prevPage=(action 'prev')}}
+                </div>
+            {{/if}}
         </div>
     </div>
     <br>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -135,11 +135,14 @@
             {{else if noResultsMessage}}
                 <div class="no-results">{{noResultsMessage}}</div>
             {{else}}
+                <div class="text-center">
+                    {{page-controls page=page totalPages=totalPages loadPage=(action 'loadPage')}}
+                </div>
                 {{#each results as |obj|}}
                     {{search-result addFilter='addFilter' obj=obj}}
                 {{/each}}
                 <div class="text-center">
-                    {{page-controls page=page totalPages=totalPages nextPage=(action 'next') prevPage=(action 'prev')}}
+                    {{page-controls page=page totalPages=totalPages loadPage=(action 'loadPage')}}
                 </div>
             {{/if}}
         </div>

--- a/app/utils/mappings.js
+++ b/app/utils/mappings.js
@@ -22,13 +22,13 @@ export const CONTROLLER_MAP = Object.freeze({
 export const PAGE_FRAGMENT_MAP = Object.freeze({
     AbstractAgent: {
         relatedWorks: (offset) => `
-          relatedWorks(offset:${offset|0}) {
+          relatedWorks(offset:${offset | 0}) {
             type: __typename
             creativeWork { id, type: __typename, title }
           }
         `,
         relatedAgents: (offset) => `
-          relatedAgents(offset:${offset|0}) {
+          relatedAgents(offset:${offset | 0}) {
             type: __typename
             related { id, type: __typename, name }
           }
@@ -36,20 +36,20 @@ export const PAGE_FRAGMENT_MAP = Object.freeze({
     },
     AbstractCreativeWork: {
         relatedWorks: (offset) => `
-          relatedWorks(offset:${offset|0}) {
+          relatedWorks(offset:${offset | 0}) {
             type: __typename
             related { id, type: __typename, title }
           }
         `,
         relatedAgents: (offset) => `
-          relatedAgents(offset:${offset|0}) {
+          relatedAgents(offset:${offset | 0}) {
             type: __typename,
             citedAs,
             agent { id, type: __typename, name }
           }
         `
     }
-})
+});
 
 // GraphQL fragments that dictate the default attributes
 // loaded for a given type in the detail route

--- a/app/utils/mappings.js
+++ b/app/utils/mappings.js
@@ -19,6 +19,38 @@ export const CONTROLLER_MAP = Object.freeze({
     // Person: 'person',
 });
 
+export const PAGE_FRAGMENT_MAP = Object.freeze({
+    agent: {
+        relatedWorks: (offset) => `
+          relatedWorks(offset:${offset|0}) {
+            type: __typename
+            creativeWork { id, type: __typename, title }
+          }
+        `,
+        relatedAgents: (offset) => `
+          relatedAgents(offset:${offset|0}) {
+            type: __typename
+            related { id, type: __typename, name }
+          }
+        `
+    },
+    work: {
+        relatedWorks: (offset) => `
+          relatedWorks(offset:${offset|0}) {
+            type: __typename
+            related { id, type: __typename, title }
+          }
+        `,
+        relatedAgents: (offset) => `
+          relatedAgents(offset:${offset|0}) {
+            type: __typename,
+            citedAs,
+            agent { id, type: __typename, name }
+          }
+        `
+    }
+})
+
 // GraphQL fragments that dictate the default attributes
 // loaded for a given type in the detail route
 export const FRAGMENT_MAP = Object.freeze({
@@ -29,22 +61,13 @@ export const FRAGMENT_MAP = Object.freeze({
       tags { name },
       identifiers { scheme, host, uri },
 
-      relatedAgents {
-        type: __typename,
-        citedAs,
-        agent { id, type: __typename, name }
-      }
+      ${PAGE_FRAGMENT_MAP.work.relatedAgents()}
     }`,
 
     AbstractAgent: `{
       name,
       identifiers { scheme, host, uri },
-    }`,
-
-    Person: `{
-      relatedWorks {
-        type: __typename
-        creativeWork { id, type: __typename, title }
-      }
+      totalRelatedWorks,
+      ${PAGE_FRAGMENT_MAP.agent.relatedWorks()}
     }`,
 });

--- a/app/utils/mappings.js
+++ b/app/utils/mappings.js
@@ -20,7 +20,7 @@ export const CONTROLLER_MAP = Object.freeze({
 });
 
 export const PAGE_FRAGMENT_MAP = Object.freeze({
-    agent: {
+    AbstractAgent: {
         relatedWorks: (offset) => `
           relatedWorks(offset:${offset|0}) {
             type: __typename
@@ -34,7 +34,7 @@ export const PAGE_FRAGMENT_MAP = Object.freeze({
           }
         `
     },
-    work: {
+    AbstractCreativeWork: {
         relatedWorks: (offset) => `
           relatedWorks(offset:${offset|0}) {
             type: __typename
@@ -61,13 +61,13 @@ export const FRAGMENT_MAP = Object.freeze({
       tags { name },
       identifiers { scheme, host, uri },
 
-      ${PAGE_FRAGMENT_MAP.work.relatedAgents()}
+      ${PAGE_FRAGMENT_MAP.AbstractCreativeWork.relatedAgents()}
     }`,
 
     AbstractAgent: `{
       name,
       identifiers { scheme, host, uri },
       totalRelatedWorks,
-      ${PAGE_FRAGMENT_MAP.agent.relatedWorks()}
+      ${PAGE_FRAGMENT_MAP.AbstractAgent.relatedWorks()}
     }`,
 });

--- a/app/utils/mappings.js
+++ b/app/utils/mappings.js
@@ -35,8 +35,14 @@ export const PAGE_FRAGMENT_MAP = Object.freeze({
         `
     },
     AbstractCreativeWork: {
-        relatedWorks: (offset) => `
-          relatedWorks(offset:${offset | 0}) {
+        incomingWorkRelations: (offset) => `
+          incomingWorkRelations(offset:${offset | 0}) {
+            type: __typename
+            subject { id, type: __typename, title }
+          }
+        `,
+        outgoingWorkRelations: (offset) => `
+          outgoingWorkRelations(offset:${offset | 0}) {
             type: __typename
             related { id, type: __typename, title }
           }
@@ -61,13 +67,16 @@ export const FRAGMENT_MAP = Object.freeze({
       tags { name },
       identifiers { scheme, host, uri },
 
-      ${PAGE_FRAGMENT_MAP.AbstractCreativeWork.relatedAgents()}
+      ${PAGE_FRAGMENT_MAP.AbstractCreativeWork.relatedAgents()},
+      ${PAGE_FRAGMENT_MAP.AbstractCreativeWork.incomingWorkRelations()},
+      ${PAGE_FRAGMENT_MAP.AbstractCreativeWork.outgoingWorkRelations()},
     }`,
 
     AbstractAgent: `{
       name,
       identifiers { scheme, host, uri },
       totalRelatedWorks,
-      ${PAGE_FRAGMENT_MAP.AbstractAgent.relatedWorks()}
+      ${PAGE_FRAGMENT_MAP.AbstractAgent.relatedWorks()},
+      ${PAGE_FRAGMENT_MAP.AbstractAgent.relatedAgents()},
     }`,
 });

--- a/tests/unit/helpers/eq-test.js
+++ b/tests/unit/helpers/eq-test.js
@@ -1,0 +1,10 @@
+import { eq } from 'ember-share/helpers/eq';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | eq');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = eq([42]);
+  assert.ok(result);
+});

--- a/tests/unit/helpers/prettify-test.js
+++ b/tests/unit/helpers/prettify-test.js
@@ -1,0 +1,10 @@
+import { prettify } from 'ember-share/helpers/prettify';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | prettify');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = prettify([42]);
+  assert.ok(result);
+});


### PR DESCRIPTION
- Add a `page-controls` component
- Show (paginated) related works on all agents' detail page
  - Display relation type for each work -- thoughts on better ways to do this welcome
- Paginate the discover page, and add `page` query param

Organization related works:
<img width="1262" alt="screen shot 2016-11-18 at 5 19 09 pm" src="https://cloud.githubusercontent.com/assets/6776190/20448715/6254f276-adb3-11e6-86fe-41f84de685bd.png">


Discover page:
<img width="1020" alt="screen shot 2016-11-18 at 5 23 20 pm" src="https://cloud.githubusercontent.com/assets/6776190/20448823/d59e2950-adb3-11e6-822e-7164d3983bb3.png">

