### PR TITLE
[SHARE-480][Feature] Search error messages

### DIFF
--- a/app/components/query-syntax/component.js
+++ b/app/components/query-syntax/component.js
@@ -2,14 +2,29 @@ import Ember from 'ember';
 import ENV from '../../config/environment';
 
 export default Ember.Component.extend({
+    showFields: false,
+
     init() {
         this._super(...arguments);
         Ember.$.ajax({
             url: ENV.apiUrl + '/search/_mappings/creativeworks',
             contentType: 'application/json',
         }).then((json) => {
-            // TODO handle nested fields, like `lists`
-            this.set('fields', Object.keys(json.share.mappings.creativeworks.properties).sort());
+            const properties = json.share.mappings.creativeworks.properties;
+            const fields = [];
+            for(const name in properties) {
+                const type = properties[name].type;
+                if (type) {
+                    fields.pushObject({ name, type: properties[name].type});
+                }
+            }
+            this.set('fields', fields.sortBy('name'));
         });
+    },
+
+    actions: {
+        toggleFields() {
+            this.toggleProperty('showFields');
+        }
     }
 });

--- a/app/components/query-syntax/component.js
+++ b/app/components/query-syntax/component.js
@@ -12,10 +12,10 @@ export default Ember.Component.extend({
         }).then((json) => {
             const properties = json.share.mappings.creativeworks.properties;
             const fields = [];
-            for(const name in properties) {
+            for (const name in properties) {
                 const type = properties[name].type;
                 if (type) {
-                    fields.pushObject({ name, type: properties[name].type});
+                    fields.pushObject({ name, type: properties[name].type });
                 }
             }
             this.set('fields', fields.sortBy('name'));

--- a/app/components/query-syntax/component.js
+++ b/app/components/query-syntax/component.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+import ENV from '../../config/environment';
+
+export default Ember.Component.extend({
+    init() {
+        this._super(...arguments);
+        Ember.$.ajax({
+            url: ENV.apiUrl + '/search/_mappings/creativeworks',
+            contentType: 'application/json',
+        }).then((json) => {
+            // TODO handle nested fields, like `lists`
+            this.set('fields', Object.keys(json.share.mappings.creativeworks.properties).sort());
+        });
+    }
+});

--- a/app/components/query-syntax/template.hbs
+++ b/app/components/query-syntax/template.hbs
@@ -2,8 +2,8 @@
     <h1>{{message}}</h1>
 {{/if}}
 <h2>Query Syntax</h2>
-<div class='col-xs-12 col-med-6'>
-    <h3>Reserved characters</h3>
+<div>
+    <h3>Reserved Characters</h3>
     <p>
         The following characters have special meanings in a query:
         <code>+ - = &amp;&amp; || &gt; &lt; ! ( ) { } [ ] ^ " ~ * ? : \ /</code>
@@ -13,7 +13,7 @@
         For instance, to search for <code>(1+1)=2</code>, you would need to type <code>\(1\+1\)\=2</code>.
     </p>
 </div>
-<div class='col-xs-12 col-med-6'>
+<div>
     <h3>Searching by Field</h3>
     <p>
         By default, all available fields are searched, but you can choose to search specific fields instead:
@@ -24,14 +24,25 @@
         <li><code>contributors:"degrasse tyson"</code> -- The list of contributor names contains the exact phrase "degrasse tyson".</li>
         <li><code>identifiers:"10.1371/journal.pbio.1002456"</code> -- The list of identifiers contains "10.1371/journal.pbio.1002456"</li>
     </ul>
-    <h4>Available search fields</h4>
-    <ul>
-        {{#each fields as |field|}}
-            <li>{{field}}</li>
-        {{/each}}
-    </ul>
+    <i>
+        <a href='#' {{action 'toggleFields'}}>
+            Available Search Fields
+            {{#if showFields}}
+                {{fa-icon 'caret-down'}}
+            {{else}}
+                {{fa-icon 'caret-up'}}
+            {{/if}}
+        </a>
+    </i>
+    {{#if showFields}}
+        <ul>
+            {{#each fields as |field|}}
+                <li>{{field.name}} <small>({{field.type}})</small></li>
+            {{/each}}
+        </ul>
+    {{/if}}
 </div>
-<div class='col-xs-12 col-med-6'>
+<div>
     <h3>Boolean Operators</h3>
     <p>
         By default, all terms in the query are optional, as long as one term matches. You can use boolean operators (<code>+</code>, <code>-</code>, <code>AND</code>, <code>OR</code>, <code>NOT</code>) to have more control over the search:
@@ -39,32 +50,68 @@
     <ul>
         <li><code>+giraffe neck spots</code> -- The word "giraffe" <b>must</b> be present. The words "neck" and "spots" are optional but used for sorting by relevance.</li>
         <li><code>+giraffe neck spots -stripes</code> -- Same as above, except the word "stripes" <b>must not</b> be present.</li>
-        <li><code>giraffe AND lion</code> -- Both "giraffe" and "lion" <b>must</b> be present.</li>
+        <li><code>giraffe AND lion</code> -- Both "giraffe" and "lion" <b>must</b> be present. Equivalent to <code>+giraffe +lion</code>.</li>
         <li><code>giraffe AND NOT lion</code> -- The word "giraffe" <b>must</b> be present, the word "lion" <b>must not</b>. Equivalent to <code>+giraffe -lion</code>.</li>
         <li><code>tags:(ungulate OR feline)</code> -- The list of tags contains "ungulate", "feline", or both.</li>
     </ul>
 </div>
-<div class='col-xs-12 col-med-6'>
+<div>
     <h3>Wildcards</h3>
     <p>
         Use wildcards to match multiple terms at once. Use <code>?</code> to match any single character, or <code>*</code> to match zero or more characters.
     </p>
+    <ul>
+        <li><code>giraf*</code> -- Match any word that starts with "giraf".</li>
+        <li><code>l?on</code> -- Match "lion", "loon", "leon", etc.</li>
+    </ul>
 </div>
-<div class='col-xs-12 col-med-6'>
-    <h3></h3>
+<div>
+    <h3>Fuzziness</h3>
+    <p>
+        Use <code>~</code> after a word to indicate a "fuzzy" search, to include matches that are similar but not exactly the same.
+    </p>
+    <ul>
+        <li><code>girafe~ nekc~</code> -- Match "giraffe neck".</li>
+    </ul>
+    <p>
+        This uses the <a href='http://en.wikipedia.org/wiki/Damerau-Levenshtein_distance'>Damerau-Levenshtein distance</a> to match all words with at most 1 change. You can specify a different maximum edit distance with a number after the <code>~</code>.
+    </p>
+    <ul>
+        <li><code>girafe~2</code> -- Match "giraffe", "gyrate", "pirate", etc.</li>
+    </ul>
 </div>
-<div class='col-xs-12 col-med-6'>
-    <h3></h3>
+<div>
+    <h3>Phrase Proximity</h3>
+    <p>
+        You can also specify a maximum edit distance for phrases, to allow the words in the phrase to be farther apart or in a different order.
+    </p>
+    <ul>
+        <li><code>"giraffe neck"~2</code> -- Match "giraffe has a neck", but not "giraffe has a long neck".</li>
+    </ul>
 </div>
-<div class='col-xs-12 col-med-6'>
-    <h3></h3>
+<div>
+    <h3>Ranges</h3>
+    <p>
+        Use brackets to specify ranges for a field. Square brackets <code>[min TO max]</code> indicate inclusive ranges and curly brackets <code>{min TO max}</code> indicate exclusive ranges.
+    </p>
+    <ul>
+        <li><code>date:[2016-01-01 TO 2016-12-31]</code> -- Match all dates in 2016.</li>
+        <li><code>tags:{alpha TO omega}</code> -- Match all tags between "alpha" and "omega", excluding "alpha" and "omega".</li>
+        <li><code>date:[2016-01-01 TO 2016-12-31}</code> -- Match all dates in 2016 except December 31.</li>
+    </ul>
 </div>
-<div class='col-xs-12 col-med-6'>
-    <h3></h3>
+<div>
+    <h3>Boosting</h3>
+    <p>
+        Use the boost operator <code>^</code> with a number to make one term more relevant than another. The boost can be any positive number. Boosts between 0 and 1 reduce relevance.
+    </p>
+    <ul>
+        <li><code>giraffe^2 lion</code> -- Boost results with "giraffe" higher than results with just "lion".</li>
+    </ul>
 </div>
-<div class='col-xs-12 col-med-6'>
+<div>
     <h3>More Information</h3>
     <p>
-        For more details about query syntax, see the <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax'>Elasticsearch documentation</a>
+        For more details about query syntax, see the <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax'>Elasticsearch documentation</a>.
     </p>
 </div>

--- a/app/components/query-syntax/template.hbs
+++ b/app/components/query-syntax/template.hbs
@@ -1,0 +1,2 @@
+<div class='lead'>{{message}}</div>
+learn to query, dude

--- a/app/components/query-syntax/template.hbs
+++ b/app/components/query-syntax/template.hbs
@@ -1,2 +1,70 @@
-<div class='lead'>{{message}}</div>
-learn to query, dude
+{{#if message}}
+    <h1>{{message}}</h1>
+{{/if}}
+<h2>Query Syntax</h2>
+<div class='col-xs-12 col-med-6'>
+    <h3>Reserved characters</h3>
+    <p>
+        The following characters have special meanings in a query:
+        <code>+ - = &amp;&amp; || &gt; &lt; ! ( ) { } [ ] ^ " ~ * ? : \ /</code>
+    </p>
+    <p>
+        If you want to use any of these reserved characters in your query, escape them with a leading backslash.
+        For instance, to search for <code>(1+1)=2</code>, you would need to type <code>\(1\+1\)\=2</code>.
+    </p>
+</div>
+<div class='col-xs-12 col-med-6'>
+    <h3>Searching by Field</h3>
+    <p>
+        By default, all available fields are searched, but you can choose to search specific fields instead:
+    </p>
+    <ul>
+        <li><code>title:giraffe</code> -- The title contains the word "giraffe".</li>
+        <li><code>description:"giraffe neck"</code> -- The description contains the exact phrase "giraffe neck".</li>
+        <li><code>contributors:"degrasse tyson"</code> -- The list of contributor names contains the exact phrase "degrasse tyson".</li>
+        <li><code>identifiers:"10.1371/journal.pbio.1002456"</code> -- The list of identifiers contains "10.1371/journal.pbio.1002456"</li>
+    </ul>
+    <h4>Available search fields</h4>
+    <ul>
+        {{#each fields as |field|}}
+            <li>{{field}}</li>
+        {{/each}}
+    </ul>
+</div>
+<div class='col-xs-12 col-med-6'>
+    <h3>Boolean Operators</h3>
+    <p>
+        By default, all terms in the query are optional, as long as one term matches. You can use boolean operators (<code>+</code>, <code>-</code>, <code>AND</code>, <code>OR</code>, <code>NOT</code>) to have more control over the search:
+    </p>
+    <ul>
+        <li><code>+giraffe neck spots</code> -- The word "giraffe" <b>must</b> be present. The words "neck" and "spots" are optional but used for sorting by relevance.</li>
+        <li><code>+giraffe neck spots -stripes</code> -- Same as above, except the word "stripes" <b>must not</b> be present.</li>
+        <li><code>giraffe AND lion</code> -- Both "giraffe" and "lion" <b>must</b> be present.</li>
+        <li><code>giraffe AND NOT lion</code> -- The word "giraffe" <b>must</b> be present, the word "lion" <b>must not</b>. Equivalent to <code>+giraffe -lion</code>.</li>
+        <li><code>tags:(ungulate OR feline)</code> -- The list of tags contains "ungulate", "feline", or both.</li>
+    </ul>
+</div>
+<div class='col-xs-12 col-med-6'>
+    <h3>Wildcards</h3>
+    <p>
+        Use wildcards to match multiple terms at once. Use <code>?</code> to match any single character, or <code>*</code> to match zero or more characters.
+    </p>
+</div>
+<div class='col-xs-12 col-med-6'>
+    <h3></h3>
+</div>
+<div class='col-xs-12 col-med-6'>
+    <h3></h3>
+</div>
+<div class='col-xs-12 col-med-6'>
+    <h3></h3>
+</div>
+<div class='col-xs-12 col-med-6'>
+    <h3></h3>
+</div>
+<div class='col-xs-12 col-med-6'>
+    <h3>More Information</h3>
+    <p>
+        For more details about query syntax, see the <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax'>Elasticsearch documentation</a>
+    </p>
+</div>

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -222,7 +222,7 @@ export default ApplicationController.extend({
                 numberOfResults: 0,
                 results: []
             });
-            if (errorResponse.status == 400) {
+            if (errorResponse.status === 400) {
                 this.set('queryError', errorResponse.responseJSON.error.root_cause[0].reason);
             } else {
                 this.send('elasticDown');

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -216,6 +216,12 @@ export default ApplicationController.extend({
             if (this.get('totalPages') && this.get('totalPages') < this.get('page')) {
                 this.search();
             }
+        }, (response, textStatus, errorThrown) => {
+            if (response.status >= 500) {
+                this.send('elasticDown');
+                return;
+            }
+            console.log(response.responseJSON, textStatus, errorThrown)
         });
     },
 

--- a/app/helpers/eq.js
+++ b/app/helpers/eq.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-
-export function eq([left, right]) {
-    return left === right;
-}
-
-export default Ember.Helper.helper(eq);

--- a/app/router.js
+++ b/app/router.js
@@ -35,6 +35,7 @@ Router.map(function() {
     this.route('detail', { path: '/:type/:id' });
     this.route('curate', { path: '/curate/:type/:id' });
 
+    this.route('elastic-down', { path: null } );
     this.route('notfound', { path: '/*path' });
     this.route('notfound');
 });

--- a/app/router.js
+++ b/app/router.js
@@ -35,7 +35,7 @@ Router.map(function() {
     this.route('detail', { path: '/:type/:id' });
     this.route('curate', { path: '/curate/:type/:id' });
 
-    this.route('elastic-down', { path: null } );
+    this.route('elastic-down');
     this.route('notfound', { path: '/*path' });
     this.route('notfound');
 });

--- a/app/routes/discover.js
+++ b/app/routes/discover.js
@@ -22,5 +22,12 @@ export default Ember.Route.extend(RouteHistoryMixin, {
             controller.set('facetFilters', Ember.Object.create());
             controller.set('firstLoad', true);
         }
+    },
+
+    actions: {
+        elasticDown() {
+            this.intermediateTransitionTo('elastic-down');
+            return false;
+        }
     }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -236,3 +236,14 @@ hr.divider {
 .detail-bottom-padding {
     padding-bottom: 30px;
 }
+
+/* Error page */
+
+.error-image {
+    -webkit-animation:spin 600s linear infinite;
+    -moz-animation:spin 600s linear infinite;
+    animation:spin 600s linear infinite;
+}
+@-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+@-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
+@keyframes spin { 100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); } }

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -151,6 +151,8 @@
         <div class='col-sm-9 col-xs-12'>
             {{#if loading}}
                 {{loading-bars}}
+            {{else if queryError}}
+                {{query-syntax message=queryError}}
             {{else if noResultsMessage}}
                 <div class="text-center no-results">{{noResultsMessage}}</div>
             {{else}}

--- a/app/templates/elastic-down.hbs
+++ b/app/templates/elastic-down.hbs
@@ -1,7 +1,7 @@
 <div class='error-page'>
     <div class='container text-center'>
-        <h1>We'll be right back!</h1>
+        <h1>Search is Unavailable</h1>
+        <p>SHARE Search is temporarily unavailable. We have been notified and are working to fix the problem. Please try again later.</p>
         <img alt='Maintenance' src='assets/images/maintenance.png' class='error-image img-responsive center-block'>
-        <p>SHARE is down for temporary maintenance. Please excuse us while we upgrade the site.</p>
     </div>
 </div>


### PR DESCRIPTION
## Purpose
Display error messages on the discover page when a query fails, instead of leaving the loading indicator up forever.

## Changes
When Elasticsearch is unreachable (`50x` error), hide the discover page and tell them to try again later:
<img width="1279" alt="screen shot 2016-12-19 at 3 44 34 pm" src="https://cloud.githubusercontent.com/assets/6776190/21328478/206f4f84-c602-11e6-860f-c836e4ad9863.png">

When Elastic fails to parse the query (`400` error), display a quick overview of query syntax:
![screen shot 2016-12-19 at 3 42 48 pm](https://cloud.githubusercontent.com/assets/6776190/21328489/351a019a-c602-11e6-976e-d01bdf26e6e4.png)

Also, wrap the `application-error` page in a bootstrap container, so it'll look less broken.

## Ticket
https://openscience.atlassian.net/browse/SHARE-480