### PR TITLE
[SHARE-473] [Feature] Fix safari spacing bug

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -9,6 +9,11 @@
 @import 'c3';
 @import 'registration' ;
 
+/*
+    note that flex-wrap can mess spacing up in safari so use sparingly
+    https://github.com/backdrop/backdrop-issues/issues/1985
+*/
+
 
 /* Index Style */
 
@@ -45,9 +50,15 @@
     justify-content: center ;
 }
 
+
+// hide search icon on mobile to prevent strange wrapping
+@media (max-width: 420px) {
+    .index-search-icon {
+        display: none;
+    }
+}
+
 #index-tile-row {
-    display: flex ;
-    justify-content: center ;
     padding-top: 40px;
     flex-wrap: wrap ;
     margin-left: 25px;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -10,7 +10,7 @@
                         <div class="col-xs-offset-1 col-xs-10" id="index-row">
                             {{input class="form-control" enter='search' value=searchString placeholder=placeholder }}
                         </div>
-                        <div class="col-xs-1">
+                        <div class="col-xs-1 index-search-icon">
                             <a href="" {{action 'search'}}>
                                 <i style="font-size: 150%; margin-top: 5px" class="fa fa-search"></i>
                             </a>


### PR DESCRIPTION
### Purpose

Display homepage boxes in a row on safari if width allows.

### Changes

* Don't use flex-wrap on boxes
    * see [discussion](https://github.com/backdrop/backdrop-issues/issues/1985) for more details
* Hide search icon on mobile screens

Hiding icon prevents:
![screen shot 2016-12-21 at 10 14 16 am](https://cloud.githubusercontent.com/assets/7131985/21394859/46f6b72a-c768-11e6-8972-a0070465d658.png)


### Side effects

* The boxes on the hompage will not wrap on any browser -- the boxes will either be in a row or in a column.

### Ticket

https://openscience.atlassian.net/browse/SHARE-473