### PR TITLE
[SHARE-470] [Feature] Render html on discover and detail page

### DIFF
--- a/app/components/search-result/component.js
+++ b/app/components/search-result/component.js
@@ -10,11 +10,14 @@ export default Ember.Component.extend({
     type: Ember.computed('obj.type', function() {
         return this.get('obj.type').capitalize();
     }),
-    abbreviated: Ember.computed('obj.description', function() {
-        return this.get('obj.description').length > this.get('maxDescription');
+    safeDescription: Ember.computed('obj.description', function() {
+        return Ember.String.htmlSafe(this.get('obj.description')).string;
     }),
-    abbreviation: Ember.computed('obj.description', function() {
-        return this.get('obj.description').slice(0, this.get('maxDescription'));
+    abbreviated: Ember.computed('safeDescription', function() {
+        return this.get('safeDescription').length > this.get('maxDescription');
+    }),
+    abbreviation: Ember.computed('safeDescription', function() {
+        return this.get('safeDescription').slice(0, this.get('maxDescription'));
     }),
     extraContributors: Ember.computed('obj.lists.contributors', function() {
         return (this.get('obj.lists.contributors') || []).slice(this.get('maxContributors'));

--- a/app/components/search-result/template.hbs
+++ b/app/components/search-result/template.hbs
@@ -67,7 +67,7 @@
 {{#if abbreviation}}
     <div class="row description">
         <div class="col-sm-12">
-            {{abbreviation}}
+            {{{abbreviation}}}
             {{#if abbreviated}}
                 <span class="text-muted">...</span>
             {{/if}}

--- a/app/controllers/work.js
+++ b/app/controllers/work.js
@@ -35,4 +35,8 @@ export default Ember.Controller.extend(DetailMixin, {
     }),
 
     retractions: Ember.computed.filterBy('model.incomingWorkRelations', 'type', 'Retracts'),
+
+    safeDescription: Ember.computed('model.description', function() {
+        return Ember.String.htmlSafe(this.get('model.description')).string;
+    }),
 });

--- a/app/templates/work.hbs
+++ b/app/templates/work.hbs
@@ -31,8 +31,8 @@
 <div class="container">
     <br>
     <p>
-        {{#if model.description}}
-            {{model.description}}
+        {{#if safeDescription}}
+            {{{safeDescription}}}
         {{else}}
             <span class="text-muted">No description provided.</span>
         {{/if}}


### PR DESCRIPTION
*** Should be merged after https://github.com/CenterForOpenScience/SHARE/pull/548

## Purpose

Handle html in description so it is more user friendly.

## Changes

![screen shot 2016-12-21 at 1 51 01 pm](https://cloud.githubusercontent.com/assets/7131985/21405851/5d96ed64-c796-11e6-940c-d8cce32bbfec.png)
![screen shot 2016-12-21 at 2 38 59 pm](https://cloud.githubusercontent.com/assets/7131985/21405850/5d96e6e8-c796-11e6-9b7b-e07304a2968e.png)

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/SHARE-470
