### PR TITLE
[SHARE-464][Feature] Don't wrap donut tooltips.

### DIFF
--- a/app/components/search-facet-source/style.css
+++ b/app/components/search-facet-source/style.css
@@ -1,0 +1,3 @@
+.c3-tooltip {
+    white-space: nowrap;
+}


### PR DESCRIPTION
<!-- Title naming convention: 

     [ticket][target branch] Title

     - For develop use 'Feature' (e.g., [SHARE-1234][Feature] Example PR Title)
     - For master use 'Hotfix' (e.g., [SHARE-1234][Hotfix] Example PR Title)
     - For a release use the release tag (e.g., [SHARE-1234][X.Y.Z] Example PR Title) -->

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The donut tooltip likes to wrap way too much. Squash its dreams. Don't let it wrap.
<!-- Describe the purpose of your changes -->

## Changes
`white-space: nowrap;`

<img width="469" alt="screen shot 2017-01-03 at 5 06 09 pm" src="https://cloud.githubusercontent.com/assets/6776190/21624905/16d2e842-d1d7-11e6-8eeb-8430af5b63e2.png">

41 bits added per story point.
<!-- Briefly describe or list your changes, screenshots if applicable   -->

## Side effects
Very long source names could cause the tooltip to stick off the right side of the window, but only on mobile-size screens which don't have a hover tooltip, anyway.
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/SHARE-464
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SHARE-1234 -->
