### PR TITLE
use replaceWith for detail transitions

### DIFF
--- a/app/routes/detail.js
+++ b/app/routes/detail.js
@@ -61,7 +61,7 @@ export default Ember.Route.extend(RouteHistoryMixin, {
         // Correct the url
         let slug = model.type.classify().toLowerCase();
         if (slug !== transition.params.detail.type) {
-            return this.transitionTo('detail', slug, model.id);
+            return this.replaceWith('detail', slug, model.id);
         }
     }
 });


### PR DESCRIPTION
# Use `replaceWith` for transitions/redirects on detail route.



## Purpose
When someone goes to something like https://share.osf.io/agent/6424F-604-9B2 it redirects them to https://share.osf.io/person/6424F-604-9B2, but causes ember to call pushState, so hitting the back button retriggers the redirect. This fixes it.