### PR TITLE
[SHARE-600][Improvement] Don't use 'CreativeWork' in UI

### DIFF
--- a/app/components/search-facet-worktype-button/component.js
+++ b/app/components/search-facet-worktype-button/component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import ENV from '../../config/environment';
 
 export default Ember.Component.extend({
     selected: Ember.computed('selectedTypes.[]', function() {
@@ -7,6 +8,9 @@ export default Ember.Component.extend({
     }),
 
     label: Ember.computed('type', function() {
+        if (this.get('type') === 'creative work') {
+            return ENV.creativeworkName;
+        }
         // title case work types: 'creative work' --> 'Creative Work'
         return this.get('type').replace(/\w\S*/g, function(str) {return str.capitalize();});
     }),

--- a/app/components/search-facet-worktype/style.scss
+++ b/app/components/search-facet-worktype/style.scss
@@ -1,0 +1,3 @@
+.indent {
+    padding-left: 30px;
+}

--- a/app/components/search-facet-worktype/template.hbs
+++ b/app/components/search-facet-worktype/template.hbs
@@ -1,4 +1,9 @@
 <div class='filter-block'>
-    {{search-facet-worktype-hierarchy state=state defaultCollapsed=false
+    {{search-facet-worktype-hierarchy state=state defaultCollapsed=true
         data=data onClick=(action 'toggle')}}
+    <div class='indent row'>
+        {{search-facet-worktype-button type='creative work' collapsible=false
+                selectedTypes=selected onClick=(action 'toggle') toggleState=toggleState
+                toggleCollapse=false}}
+    </div>
 </div>

--- a/app/components/search-result/component.js
+++ b/app/components/search-result/component.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from './template';
+import ENV from '../../config/environment';
 
 export default Ember.Component.extend({
     layout,
@@ -8,6 +9,9 @@ export default Ember.Component.extend({
     maxDescription: 350,
 
     type: Ember.computed('obj.type', function() {
+        if (this.get('obj.type') === 'creative work') {
+            return ENV.creativeworkName;
+        }
         // title case work types: 'creative work' --> 'Creative Work'
         return this.get('obj.type').replace(/\w\S*/g, function(str) {return str.capitalize();});
     }),

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -73,7 +73,8 @@ export default ApplicationController.extend({
     }),
 
     processedTypes: Ember.computed('types', function() {
-        return this.transformTypes(this.get('types'));
+        const types = this.get('types').CreativeWork ? this.get('types').CreativeWork.children : {};
+        return this.transformTypes(types);
     }),
 
     sortOptions: [{

--- a/app/controllers/work.js
+++ b/app/controllers/work.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import DetailMixin from '../mixins/detail';
 import { RELATION_MAP } from '../utils/mappings';
+import ENV from '../config/environment';
 
 const SECTIONS = [
     { title: 'Contributors', value: 'relatedAgents.contributor', component: 'section-related-agents' },
@@ -15,6 +16,13 @@ const SECTIONS = [
 
 export default Ember.Controller.extend(DetailMixin, {
     sections: SECTIONS,
+
+    workType: Ember.computed('model.type', function() {
+        if (this.get('model.type') === 'CreativeWork') {
+            return ENV.creativeworkName;
+        }
+        return this.get('model.type');
+    }),
 
     relatedAgents: Ember.computed('model.relatedAgents', function() {
         const byType = {};

--- a/app/templates/work.hbs
+++ b/app/templates/work.hbs
@@ -22,7 +22,7 @@
             <h1 class="title">
                 {{{safeTitle}}}
                 <br>
-                <small>{{model.type}}</small>
+                <small>{{workType}}</small>
             </h1>
         </div>
     </div>

--- a/app/utils/elastic-query.js
+++ b/app/utils/elastic-query.js
@@ -36,7 +36,7 @@ function termsFilter(field, terms, all = true) {
                 let filter = { term: {} };
                 // creative work filter should not include subtypes
                 if (term === 'creative work' && field === 'types') {
-                    filter.term['type'] = term;
+                    filter.term.type = term;
                 } else {
                     filter.term[field] = term;
                 }

--- a/app/utils/elastic-query.js
+++ b/app/utils/elastic-query.js
@@ -34,7 +34,12 @@ function termsFilter(field, terms, all = true) {
         if (all) {
             return terms.map(term => {
                 let filter = { term: {} };
-                filter.term[field] = term;
+                // creative work filter should not include subtypes
+                if (term === 'creative work' && field === 'types') {
+                    filter.term['type'] = term;
+                } else {
+                    filter.term[field] = term;
+                }
                 return filter;
             });
         } else {

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,6 +5,7 @@ module.exports = function(environment) {
         modulePrefix: 'ember-share',
         environment: environment,
         baseURL: '/share/',
+        creativeworkName: 'Not Categorized',
         locationType: 'auto',
         EmberENV: {
             EXTEND_PROTOTYPES: {


### PR DESCRIPTION
## Purpose

Remove 'Creative Work' from UI to make it more user-friendly.

## Changes

- Update type on detail view
- Update type in search results
- Remove creative work in type facet and replace with 'Not Categorized'
- Update type filter for creative work

![screen shot 2017-02-15 at 1 13 09 pm](https://cloud.githubusercontent.com/assets/7131985/23035912/d69123c6-f44e-11e6-9413-c0ddee1e73b3.png)
![screen shot 2017-02-15 at 1 25 33 pm](https://cloud.githubusercontent.com/assets/7131985/23035913/d694b90a-f44e-11e6-890d-579e77d36281.png)
![screen shot 2017-02-15 at 2 23 35 pm](https://cloud.githubusercontent.com/assets/7131985/23035914/d69ccf46-f44e-11e6-82b2-d84a75a4f285.png)


## Side effects

The creative work filter now works differently than all of the other filters: it doesn't display subtypes.


## Ticket

https://openscience.atlassian.net/browse/SHARE-600
