### PR TITLE
[SHARE-602][Feature-fix] Fix arrows in Firefox

### DIFF
--- a/app/components/sortby-dropdown/styles.scss
+++ b/app/components/sortby-dropdown/styles.scss
@@ -10,3 +10,11 @@
     cursor: pointer;
     cursor: hand;
 }
+
+.display-text {
+    display: block;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    width: 100%;
+}

--- a/app/components/sortby-dropdown/template.hbs
+++ b/app/components/sortby-dropdown/template.hbs
@@ -1,8 +1,8 @@
-<button class="btn btn-select dropdown-toggle discover-filter-facets align-left"
+<button class="btn btn-select dropdown-toggle discover-filter-facets align-left display-text"
     type="button" id="sortBy" data-toggle="dropdown"
     aria-haspopup="true" aria-expanded="true">
-    Sort by: {{sortDisplay}}
     <span class="fa fa-sort pull-right sort-icon"></span>
+    Sort by: {{sortDisplay}}
 </button>
 <ul class="dropdown-menu" aria-labelledby="sortBy">
     {{#each sortOptions as |option|}}


### PR DESCRIPTION
## Purpose

Sort icon displayed below dropdown on Firefox.


## Changes

* Truncate label text in Chrome/Safari if necessary 
* Fix sort icon vertical location in Firefox

![screen shot 2017-02-24 at 4 30 23 pm](https://cloud.githubusercontent.com/assets/7131985/23367011/c2bafb84-fcd6-11e6-8d58-e09f7d34d9ea.png)


## Side effects

Firefox text still overlaps for the longest option. `text-overflow: ellipsis;` is not working for some reason.

![screen shot 2017-02-27 at 10 23 57 am](https://cloud.githubusercontent.com/assets/7131985/23367049/e07fd482-fcd6-11e6-8e4b-2244bb113d4f.png)


## Ticket

https://openscience.atlassian.net/browse/SHARE-602
