### PR TITLE
[SHARE-653][Improvement] Capitalize search bar placeholder

### DIFF
--- a/app/controllers/sources.js
+++ b/app/controllers/sources.js
@@ -10,7 +10,7 @@ export default Ember.Controller.extend({
     sources: [],
     numberOfEvents: 0,
     sourcesLastUpdated: Date().toString(),
-    placeholder: 'search aggregated sources',
+    placeholder: 'Search aggregated sources',
     loading: true,
     source_selected: '',
 


### PR DESCRIPTION
*While on this page*

## Purpose
Capitalize the placeholder in the search bar to be more consistent across pages and sites.

## Changes
![screen shot 2017-03-14 at 11 31 39 am](https://cloud.githubusercontent.com/assets/7131985/23918119/093edd4e-08c8-11e7-9ae7-6de663a184a3.png)

## Side effects

None
