### PR TITLE
[SHARE-573][Bug] Don't convert timezone in search results

### DIFF
--- a/app/components/search-result/component.js
+++ b/app/components/search-result/component.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import layout from './template';
 import ENV from '../../config/environment';
+import moment from 'moment';
 
 export default Ember.Component.extend({
     layout,
@@ -48,6 +49,12 @@ export default Ember.Component.extend({
             return retractions[0].id;
         }
         return null;
+    }),
+    datePublished: Ember.computed('obj.date_published', function() {
+        return moment(this.get('obj.date_published')).utc().format('MMMM YYYY');
+    }),
+    dateUpdated: Ember.computed('obj.date_updated', function() {
+        return moment(this.get('obj.date_updated')).utc().format('MMM DD, YYYY');
     }),
     didRender() {
         MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.$()[0]]);  // jshint ignore: line

--- a/app/components/search-result/template.hbs
+++ b/app/components/search-result/template.hbs
@@ -9,7 +9,7 @@
         {{/if}}
         {{#if obj.date_published}}
             <span class="col-xs-6 pull-right text-info text-right">
-                <span class="text-muted">Published </span>{{moment-format obj.date_published 'MMMM YYYY'}}
+                <span class="text-muted">Published </span>{{datePublished}}
             </span>
         {{/if}}
     </div>
@@ -128,7 +128,7 @@
     <div class="col-xs-6">
         {{#if obj.date_updated}}
             <span class="text-muted last-updated">
-                Last updated <span class="text-info">{{moment-format obj.date_updated 'MMM DD, YYYY'}}</span>
+                Last updated <span class="text-info">{{dateUpdated}}</span>
             </span>
         {{/if}}
     </div>


### PR DESCRIPTION
## Purpose

Don't convert timezone of date published and date updated in search results.

## Changes

Ensured times stayed in UTC by not using the `moment-format` helper in the search results.

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/SHARE-573
