### PR TITLE
[SHARE-634][Improvement] Make the discover page consistent

### DIFF
--- a/app/components/faceted-search/style.scss
+++ b/app/components/faceted-search/style.scss
@@ -1,6 +1,7 @@
 $discover-background-color: lighten(lightslategray, 45%);
 $darkest-color: #222;
-$placeholder-color: #4f5050;
+$gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
+$facet-separator-color: #AAA;
 
 .panel-default {
     font-family: 'Open Sans' , 'Helvetica Neue' , sans-serif;
@@ -9,7 +10,7 @@ $placeholder-color: #4f5050;
     border-bottom-width: 0;
     border-right-width: 0;
     border-left-width: 0;
-    border-color: #AAA;
+    border-color: $facet-separator-color;
     margin-bottom: 5px;
 
     > .panel-heading {
@@ -52,25 +53,25 @@ $placeholder-color: #4f5050;
 }
 
 .ember-power-select-placeholder {
-    color: $placeholder-color;
+    color: $gray-color;
 }
 
 ::-webkit-input-placeholder { /* WebKit, Blink, Edge */
-    color: $placeholder-color;
+    color: $gray-color;
 }
 
 :-moz-placeholder { /* Mozilla Firefox 4 to 18 */
-    color: $placeholder-color;
+    color: $gray-color;
     opacity: 1;
 }
 
 ::-moz-placeholder { /* Mozilla Firefox 19+ */
-    color: $placeholder-color;
+    color: $gray-color;
     opacity: 1;
 }
 
 :-ms-input-placeholder { /* Internet Explorer 10-11 */
-    color: $placeholder-color;
+    color: $gray-color;
 }
 
 .ember-power-select-status-icon{

--- a/app/components/faceted-search/style.scss
+++ b/app/components/faceted-search/style.scss
@@ -2,6 +2,9 @@ $discover-background-color: lighten(lightslategray, 45%);
 $darkest-color: #222;
 $gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
 $facet-separator-color: #AAA;
+$text-muted: #777777;
+$default-text-color: #4f5050;
+$default-text-color-active: #4285f4;
 
 .panel-default {
     font-family: 'Open Sans' , 'Helvetica Neue' , sans-serif;
@@ -36,8 +39,17 @@ $facet-separator-color: #AAA;
 
 .discover-btn-select {
     background-color: $discover-background-color;
-    color: $darkest-color;
+    color: $default-text-color;
     padding: 0px;
+    border-width: 0px;
+}
+
+.discover-btn-select:hover {
+    color: $darkest-color;
+}
+
+.discover-btn-select:active {
+    color: $default-text-color-active;
 }
 
 .ember-power-select-trigger {
@@ -47,31 +59,42 @@ $facet-separator-color: #AAA;
     padding: 0px;
 }
 
+.ember-power-select-multiple-option {
+    background-color: white;
+    color: $darkest-color;
+    border: 1px solid #ccc;
+}
+
+.ember-power-select-multiple-remove-btn {
+    color: #a94442;  // text-danger
+    font-weight: 900;
+}
+
 .ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded="true"],
 .ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded="true"] {
     border-bottom-color: $darkest-color;
 }
 
 .ember-power-select-placeholder {
-    color: $gray-color;
+    color: $text-muted;
 }
 
 ::-webkit-input-placeholder { /* WebKit, Blink, Edge */
-    color: $gray-color;
+    color: $text-muted;
 }
 
 :-moz-placeholder { /* Mozilla Firefox 4 to 18 */
-    color: $gray-color;
+    color: $text-muted;
     opacity: 1;
 }
 
 ::-moz-placeholder { /* Mozilla Firefox 19+ */
-    color: $gray-color;
+    color: $text-muted;
     opacity: 1;
 }
 
 :-ms-input-placeholder { /* Internet Explorer 10-11 */
-    color: $gray-color;
+    color: $text-muted;
 }
 
 .ember-power-select-status-icon{

--- a/app/components/faceted-search/style.scss
+++ b/app/components/faceted-search/style.scss
@@ -4,7 +4,7 @@ $gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
 $facet-separator-color: #AAA;
 $text-muted: #777777;
 $default-text-color: #4f5050;
-$default-text-color-active: #4285f4;
+$default-text-color-active: #337ab7;
 
 .panel-default {
     font-family: 'Open Sans' , 'Helvetica Neue' , sans-serif;

--- a/app/components/faceted-search/style.scss
+++ b/app/components/faceted-search/style.scss
@@ -1,9 +1,14 @@
+// lightslategray is a blue-gray color
 $discover-background-color: lighten(lightslategray, 45%);
-$darkest-color: #222;
-$gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
-$facet-separator-color: #AAA;
 $text-muted: #777777;
+
+// light gray
+$facet-separator-color: #AAA;
+// minumum gray contrast that meets WCAG 2.0 AA/AAA standards
 $default-text-color: #4f5050;
+// use for hover on buttons and dark text
+$darkest-color: #222;
+// bright blue
 $default-text-color-active: #337ab7;
 
 .panel-default {

--- a/app/components/faceted-search/style.scss
+++ b/app/components/faceted-search/style.scss
@@ -9,16 +9,17 @@
     margin-bottom: 5px;
 
     > .panel-heading {
-          background-color: white;
-          display: flex;
-          align-items: left;
-          justify-content: left;
-          border-color: transparent;
-          color: black;
-          padding-top: 5px;
-          padding-left: 0px;
-          padding-right: 0px;
-          padding-bottom: 0px;
+        // test
+        background-color: lighten(lightslategray, 45%);
+        display: flex;
+        align-items: left;
+        justify-content: left;
+        border-color: transparent;
+        color: black;
+        padding-top: 5px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-bottom: 0px;
     }
 }
 
@@ -26,17 +27,21 @@
     padding-top: 0px;
     padding-left: 0px;
     padding-right: 0px;
+    // test
+    background-color: lighten(lightslategray, 45%);
 }
 
 .btn-select {
-    background-color: white;
+    // test
+    background-color: lighten(lightslategray, 45%);
     color: black;
     padding: 0px;
 }
 
 .ember-power-select-trigger {
     color: black;
-    background-color: white;
+    // test
+    background-color: lighten(lightslategray, 45%);
     border-color: transparent;
     padding: 0px;
 }

--- a/app/components/faceted-search/style.scss
+++ b/app/components/faceted-search/style.scss
@@ -1,3 +1,7 @@
+$discover-background-color: lighten(lightslategray, 45%);
+$darkest-color: #222;
+$placeholder-color: #4f5050;
+
 .panel-default {
     font-family: 'Open Sans' , 'Helvetica Neue' , sans-serif;
     -webkit-font-smoothing: antialiased ;
@@ -9,13 +13,12 @@
     margin-bottom: 5px;
 
     > .panel-heading {
-        // test
-        background-color: lighten(lightslategray, 45%);
+        background-color: $discover-background-color;
         display: flex;
         align-items: left;
         justify-content: left;
         border-color: transparent;
-        color: black;
+        color: $darkest-color;
         padding-top: 5px;
         padding-left: 0px;
         padding-right: 0px;
@@ -27,50 +30,47 @@
     padding-top: 0px;
     padding-left: 0px;
     padding-right: 0px;
-    // test
-    background-color: lighten(lightslategray, 45%);
+    background-color: $discover-background-color;
 }
 
-.btn-select {
-    // test
-    background-color: lighten(lightslategray, 45%);
-    color: black;
+.discover-btn-select {
+    background-color: $discover-background-color;
+    color: $darkest-color;
     padding: 0px;
 }
 
 .ember-power-select-trigger {
-    color: black;
-    // test
-    background-color: lighten(lightslategray, 45%);
+    color: $darkest-color;
+    background-color: $discover-background-color;
     border-color: transparent;
     padding: 0px;
 }
 
 .ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded="true"],
 .ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded="true"] {
-    border-bottom-color: black;
+    border-bottom-color: $darkest-color;
 }
 
 .ember-power-select-placeholder {
-    color: #4f5050;
+    color: $placeholder-color;
 }
 
 ::-webkit-input-placeholder { /* WebKit, Blink, Edge */
-    color: #4f5050;
+    color: $placeholder-color;
 }
 
 :-moz-placeholder { /* Mozilla Firefox 4 to 18 */
-    color: #4f5050;
+    color: $placeholder-color;
     opacity: 1;
 }
 
 ::-moz-placeholder { /* Mozilla Firefox 19+ */
-    color: #4f5050;
+    color: $placeholder-color;
     opacity: 1;
 }
 
 :-ms-input-placeholder { /* Internet Explorer 10-11 */
-    color: #4f5050;
+    color: $placeholder-color;
 }
 
 .ember-power-select-status-icon{

--- a/app/components/help-text-tooltip/template.hbs
+++ b/app/components/help-text-tooltip/template.hbs
@@ -1,5 +1,5 @@
 <div class="fa fa-question-circle pull-right help-icon">
-    {{#tooltip-on-component side='right'}}
+    {{#tooltip-on-component side='top'}}
         {{{helpText}}}
     {{/tooltip-on-component}}
 </div>

--- a/app/components/navbar-component/style.scss
+++ b/app/components/navbar-component/style.scss
@@ -1,63 +1,66 @@
 & {
-  margin-bottom: 0px;
-  border-bottom: none;
+    margin-bottom: 0px;
+    border-bottom: none;
 
-  a {
-    color: #ffffff;
+    a {
+        color: #ffffff;
 
-    &:hover {
-      color: rgba(255, 255, 255, 0.8);
-      cursor: pointer;
+        &:hover {
+            color: rgba(255, 255, 255, 0.8);
+            cursor: pointer;
+        }
     }
-  }
 
-  .navbar-inverse .navbar-nav > li > a {
-    color: #ffffff;
+    .navbar-inverse .navbar-nav > li > a {
+        color: #ffffff;
 
-    &:hover {
-      color: rgba(255, 255, 255, 0.8);
-      cursor: pointer;
+        &:hover {
+            color: rgba(255, 255, 255, 0.8);
+            cursor: pointer;
+        }
     }
-  }
 
-  .login-btn {
-    padding: 2px 15px;
-    margin: 12px 15px;
+    .login-btn {
+        padding: 2px 15px;
+        margin: 12px 15px;
 
-    &:hover {
-      background-color: #31b0d5 !important;
+        &:hover {
+            background-color: #31b0d5 !important;
+        }
     }
-  }
 
-  .nav-user-dropdown {
-    padding-top: 12px;
-    padding-bottom: 8px;
-  }
+    .nav-user-dropdown {
+        padding-top: 12px;
+        padding-bottom: 8px;
+    }
 
-  .navbar-header {
-    padding-top: 2px;
-  }
+    .navbar-header {
+        padding-top: 2px;
+    }
 
-  .share {
-    color: white ;
-    font-size: 18px ;
-    padding-left: 10px;
-    line-height: 45px ;
-    background-color: transparent ;
+    .share {
+        color: white ;
+        font-size: 18px ;
+        padding-left: 10px;
+        line-height: 45px ;
+        background-color: transparent ;
+    }
 
-  }
+    .navbar-logo {
+        margin-top: 10px;
+        margin-left: 5px;
+        float: left;
+        height: 25px;
+    }
 
-  .navbar-logo {
-    margin-top: 10px;
-    margin-left: 5px;
-    float: left;
-    height: 25px;
-  }
+    .share-logo {
+        text-decoration: none;
+    }
 
-  .share-logo {
-    text-decoration: none;
-  }
+}
 
+.navbar-container {
+    max-width: 1050px;  // max width of discover + padding
 }
 
 .gravatar > img {
@@ -67,9 +70,9 @@
 
 
 .dropdown-menu {
-  border: 1px solid rgba(100, 100, 100, 0.3);
+    border: 1px solid rgba(100, 100, 100, 0.3);
 }
 
 .dropdown-menu > li > a:hover {
-  color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.8);
 }

--- a/app/components/navbar-component/template.hbs
+++ b/app/components/navbar-component/template.hbs
@@ -1,52 +1,47 @@
 <div class="navbar-inverse">
-<div class="container">
-  <div class="navbar-header">
-    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-expanded="false">
-      <span class="sr-only">Toggle navigation</span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-    </button>
-    {{#link-to 'index' invokeAction=(action 'track' 'homepage') class='share-logo'}}
-      <img class='navbar-logo' height='35px' width='auto' src='assets/images/nav_logo.png'>
-      <span class="share hidden-xs"> S H A R E</span>
-    {{/link-to}}
-  </div>
+    <div class="container navbar-container">
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            {{#link-to 'index' invokeAction=(action 'track' 'homepage') class='share-logo'}}
+                <img class='navbar-logo' height='35px' width='auto' src='assets/images/nav_logo.png'>
+                <span class="share hidden-xs"> S H A R E</span>
+            {{/link-to}}
+        </div>
 
-  <div class="collapse navbar-collapse" id="navbar-collapse">
-    <ul class="nav navbar-nav navbar-right">
-      <li>
-        {{link-to 'Discover' 'discover' class='nav-link' }}
-      </li>
-      <li>
-        <a class="nav-link" href="https://osf.io/cpsin/wiki/home/?view">FAQ</a>
-      </li>
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+            <ul class="nav navbar-nav navbar-right">
+                <li>{{link-to 'Discover' 'discover' class='nav-link' }}</li>
+                <li><a class="nav-link" href="https://osf.io/cpsin/wiki/home/?view">FAQ</a></li>
 
-      {{#if session.isAuthenticated}}
-        <li class="dropdown">
-          <a class="nav-user-dropdown" role="button" data-toggle="dropdown">
-            <span class="gravatar">
-              <img class="img-circle" src={{gravatarSrc}}>
-            </span>
-            <span class="username">{{userName}}</span>
-            <span class="caret"></span>
-          </a>
-          <ul class="dropdown-menu">
-            <li>{{#link-to 'profile' invokeAction=(action 'track' 'my profile')}}<i class="fa fa-user" aria-hidden="true"></i> My Profile{{/link-to}}</li>
-              {{!-- TODO: remove curationEnabled check when curation is enabled on production --}}
-              {{#if curationEnabled}}
-                <li>{{link-to 'Changes' 'changes' class='nav-link'}}</li>
-              {{/if}}
-              <li><a {{action 'logout'}}><i class="fa fa-sign-out" aria-hidden="true"></i> Log out</a></li>
-              <!--  {{#link-to 'settings'}}<i class="fa fa-cog" aria-hidden="true"></i> Settings{{/link-to}} -->
+                {{#if session.isAuthenticated}}
+                    <li class="dropdown">
+                        <a class="nav-user-dropdown" role="button" data-toggle="dropdown">
+                            <span class="gravatar">
+                                <img class="img-circle" src={{gravatarSrc}}>
+                            </span>
+                            <span class="username">{{userName}}</span>
+                            <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            <li>
+                                {{#link-to 'profile' invokeAction=(action 'track' 'my profile')}}
+                                    <i class="fa fa-user" aria-hidden="true"></i> My Profile
+                                {{/link-to}}
+                            </li>
+                            <li><a {{action 'logout'}}><i class="fa fa-sign-out" aria-hidden="true"></i> Log out</a></li>
+                        </ul>
+                    </li>
+                {{else}}
+                    <li>
+                        <a class="btn btn-info navbar-btn login-btn" {{action 'login'}}>Sign in with OSF</a>
+                    </li>
+                {{/if}}
             </ul>
-        </li>
-      {{else}}
-        <li>
-          <a class="btn btn-info navbar-btn login-btn" {{action 'login'}}>Sign in with OSF</a>
-        </li>
-      {{/if}}
-    </ul>
-</div>
-</div>
+        </div>
+    </div>
 </div>

--- a/app/components/search-facet-daterange/component.js
+++ b/app/components/search-facet-daterange/component.js
@@ -107,7 +107,7 @@ export default Ember.Component.extend({
     },
 
     noFilter() {
-        this.set('pickerValue', 'All time');
+        this.set('pickerValue', 'All dates');
     },
 
     actions: {

--- a/app/components/search-facet-daterange/style.scss
+++ b/app/components/search-facet-daterange/style.scss
@@ -1,11 +1,24 @@
+$darkest-color: #222;
+$default-text-color: #4f5050;
+$default-text-color-active: #4285f4;
+
 .date-range {
     cursor: pointer;
     padding: 0px;
     width: 100%;
+    color: $default-text-color;
 
     > .fa-caret-down {
         padding-right: 4px;
     }
+}
+
+.date-range:hover {
+    color: $darkest-color;
+}
+
+.date-range:active {
+    color: $default-text-color-active;
 }
 
 .icon {

--- a/app/components/search-facet-daterange/style.scss
+++ b/app/components/search-facet-daterange/style.scss
@@ -1,6 +1,6 @@
 $darkest-color: #222;
 $default-text-color: #4f5050;
-$default-text-color-active: #4285f4;
+$default-text-color-active: #337ab7;
 
 .date-range {
     cursor: pointer;

--- a/app/components/search-facet-daterange/style.scss
+++ b/app/components/search-facet-daterange/style.scss
@@ -1,5 +1,8 @@
-$darkest-color: #222;
+// minumum gray contrast that meets WCAG 2.0 AA/AAA standards
 $default-text-color: #4f5050;
+// use for hover on buttons and dark text
+$darkest-color: #222;
+// bright blue
 $default-text-color-active: #337ab7;
 
 .date-range {

--- a/app/components/search-facet-daterange/template.hbs
+++ b/app/components/search-facet-daterange/template.hbs
@@ -1,11 +1,11 @@
 <div class="dropdown">
-    <button class="btn btn-select dropdown-toggle discover-filter-facets align-left display-text dropdown"
+    <button class="btn btn-select discover-btn-select dropdown-toggle discover-filter-facets align-left display-text dropdown"
         type="button" id="filterBy" data-toggle="dropdown"
         aria-haspopup="true" aria-expanded="true">
         <span class="fa fa-caret-down pull-right icon"></span>
         Filter by: {{filterDisplay}}
     </button>
-    <ul class="dropdown-menu dropdown" aria-labelledby="filterBy">
+    <ul class="dropdown-menu discover-dropdown-menu dropdown" aria-labelledby="filterBy">
         {{#each filterOptions as |option|}}
             <li class="dropdown-cursor">
                 <a {{action "select" option.filterBy}}>{{option.display}}</a>

--- a/app/components/search-facet-daterange/template.hbs
+++ b/app/components/search-facet-daterange/template.hbs
@@ -1,5 +1,5 @@
 <div class="dropdown">
-    <button class="btn btn-select discover-btn-select dropdown-toggle discover-filter-facets align-left display-text dropdown"
+    <button class="discover-btn-select dropdown-toggle discover-filter-facets align-left display-text dropdown"
         type="button" id="filterBy" data-toggle="dropdown"
         aria-haspopup="true" aria-expanded="true">
         <span class="fa fa-caret-down pull-right icon"></span>

--- a/app/components/search-facet-worktype-button/style.scss
+++ b/app/components/search-facet-worktype-button/style.scss
@@ -1,6 +1,6 @@
 $darkest-color: #222;
 $default-text-color: #4f5050;
-$default-text-color-active: #4285f4;
+$default-text-color-active: #337ab7;
 
 .clickable {
     cursor: pointer;

--- a/app/components/search-facet-worktype-button/style.scss
+++ b/app/components/search-facet-worktype-button/style.scss
@@ -3,7 +3,6 @@
 }
 
 .close-icon {
-    color: red;
     padding-left: 15px;
 }
 

--- a/app/components/search-facet-worktype-button/style.scss
+++ b/app/components/search-facet-worktype-button/style.scss
@@ -1,18 +1,22 @@
+$darkest-color: #222;
+$default-text-color: #4f5050;
+$default-text-color-active: #4285f4;
+
 .clickable {
     cursor: pointer;
 }
 
 .close-icon {
-    padding-left: 15px;
+    padding-left: 8px;
 }
 
 .bubble {
     background-color: white;
-    border: .5px solid #ccc;
-    border-radius: 10px;
-    padding-left: 8px;
-    padding-right: 8px;
-    margin-left: -9px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 0 4px;
+    margin: 2px 3px 2px 0;
+    margin-left: -5px;  // prevents it from moving when selected
 }
 
 .type-filter-option {
@@ -27,13 +31,22 @@
 }
 
 a {
-    color: #333333;
+    color: $default-text-color;
+}
+
+a:hover {
+    color: $darkest-color;
+    text-decoration: none;
+}
+
+a:active {
+    color: $default-text-color-active
 }
 
 .bubble > a {
-    color: black;
+    color: $darkest-color;
 }
 
 .active {
-    color: black;
+    color: $darkest-color;
 }

--- a/app/components/search-facet-worktype-button/template.hbs
+++ b/app/components/search-facet-worktype-button/template.hbs
@@ -5,7 +5,7 @@
     <span class={{if selected 'bubble'}}>
         <a class='clickable' {{action 'click'}}>{{label}}</a>
         {{#if selected}}
-            <i class='fa fa-times close-icon clickable' {{action 'click'}}></i>
+            <i class='fa fa-times text-danger close-icon clickable' {{action 'click'}}></i>
         {{/if}}
     </span>
 </div>

--- a/app/components/search-result/component.js
+++ b/app/components/search-result/component.js
@@ -52,7 +52,7 @@ export default Ember.Component.extend({
         return null;
     }),
     datePublished: Ember.computed('obj.date_published', function() {
-        return moment(this.get('obj.date_published')).utc().format('MMMM YYYY');
+        return moment(this.get('obj.date_published')).utc().format('YYYY');
     }),
     dateUpdated: Ember.computed('obj.date_updated', function() {
         return moment(this.get('obj.date_updated')).utc().format('MMM DD, YYYY');

--- a/app/components/search-result/component.js
+++ b/app/components/search-result/component.js
@@ -27,7 +27,8 @@ export default Ember.Component.extend({
         return this.get('safeDescription').length > this.get('maxDescription');
     }),
     abbreviation: Ember.computed('safeDescription', function() {
-        return this.get('safeDescription').slice(0, this.get('maxDescription'));
+        const trimmedDescription = this.get('safeDescription').slice(0, this.get('maxDescription'));
+        return trimmedDescription.substr(0, Math.min(trimmedDescription.length, trimmedDescription.lastIndexOf(' ')));
     }),
     allCreators: Ember.computed('obj.lists.contributors', function() {
         return (this.get('obj.lists.contributors') || []).filterBy('relation', 'creator').sortBy('order_cited');

--- a/app/components/search-result/style.scss
+++ b/app/components/search-result/style.scss
@@ -39,7 +39,7 @@ $default-link-hover-color: #23527c;
 
 .tag {
     border-radius: 5px;
-    color: black;
+    color: $darkest-color;
     padding-top: 4px;
     padding-bottom: 4px;
     padding-left: 4px;

--- a/app/components/search-result/style.scss
+++ b/app/components/search-result/style.scss
@@ -81,6 +81,10 @@ $default-link-hover-color: #23527c;
     padding-right: 0px;
 }
 
+.date-line-padding {
+    padding: 0px 15px 0px 15px;
+}
+
 .default-line-padding {
     padding: 2px 15px 2px 15px;
 }

--- a/app/components/search-result/style.scss
+++ b/app/components/search-result/style.scss
@@ -1,3 +1,9 @@
+$darkest-color: #222;
+$gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
+$default-text-color: #4f5050;
+$default-text-color-active: #337ab7;
+$default-link-hover-color: #23527c;
+
 .row {
     font-family: 'Open Sans' , 'Helvetica Neue' , sans-serif;
     -webkit-font-smoothing: antialiased;
@@ -6,11 +12,15 @@
 }
 
 .text-data {
-    color: black;
+    color: $darkest-color;
 }
 
-.title > .redirect > a{
-    color: black;
+.title > .redirect > a {
+    color: darken($default-text-color-active, 10%)
+}
+
+.title > .redirect > a:hover {
+    color: darken($default-text-color-active, 20%)
 }
 
 .title-tile {
@@ -54,7 +64,12 @@
 }
 
 .redirect > a {
-    color: #337ab7;
+    color: $default-text-color-active;
+}
+
+.redirect > a:hover {
+    text-decoration: none;
+    color: $default-link-hover-color;
 }
 
 .redirect {
@@ -89,4 +104,8 @@
 
 .retraction-alert {
     padding: 2px 8px;
+}
+
+.default-cursor {
+    cursor: default;
 }

--- a/app/components/search-result/style.scss
+++ b/app/components/search-result/style.scss
@@ -49,7 +49,7 @@ $default-link-hover-color: #23527c;
     border-radius: 4px;
     border: 1px solid #ccc;
     padding: 2px 4px 2px 4px;
-    margin: 2px 4px 2px 0px;
+    margin: 4px 4px 4px 0px;
 }
 
 .worktype {
@@ -81,12 +81,16 @@ $default-link-hover-color: #23527c;
     padding-right: 0px;
 }
 
+.description-ellipsis {
+    margin-left: -4px;
+}
+
 .date-line-padding {
     padding: 0px 15px 0px 15px;
 }
 
 .default-line-padding {
-    padding: 2px 15px 2px 15px;
+    padding: 4px 15px 4px 15px;
 }
 
 .default-cursor {

--- a/app/components/search-result/style.scss
+++ b/app/components/search-result/style.scss
@@ -23,14 +23,18 @@ $default-link-hover-color: #23527c;
     color: darken($default-text-color-active, 20%)
 }
 
+.title {
+    padding-bottom: 0px;
+}
+
 .title-tile {
     padding-left: 15px;
     padding-right: 15px;
-    padding-top: 5px;
+    padding-top: 15px;
 }
 
 .published {
-    padding-right: 15px;
+    padding-left: 4px;
 }
 
 .tag {
@@ -54,15 +58,6 @@ $default-link-hover-color: #23527c;
     padding-bottom: 10px;
 }
 
-.worktype-inner a{
-    background-color: white;
-    color: black;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
-    min-width: 80px;
-    max-width: 80px;
-    height:26px;
-}
-
 .redirect > a {
     color: $default-text-color-active;
 }
@@ -82,6 +77,10 @@ $default-link-hover-color: #23527c;
     padding-bottom: 8px;
     padding-left: 15px;
     padding-right: 15px;
+}
+
+.source-text {
+    color: $darkest-color;
 }
 
 .extra {

--- a/app/components/search-result/style.scss
+++ b/app/components/search-result/style.scss
@@ -1,7 +1,8 @@
-$darkest-color: #222;
-$gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
+// minumum gray contrast that meets WCAG 2.0 AA/AAA standards
 $default-text-color: #4f5050;
+// bright blue
 $default-text-color-active: #337ab7;
+// dark blue
 $default-link-hover-color: #23527c;
 
 .row {
@@ -12,7 +13,11 @@ $default-link-hover-color: #23527c;
 }
 
 .text-data {
-    color: $darkest-color;
+    color: $default-text-color;
+}
+
+.source-text {
+    color: $default-text-color;
 }
 
 .title > .redirect > a {
@@ -24,7 +29,7 @@ $default-link-hover-color: #23527c;
 }
 
 .title {
-    padding-bottom: 0px;
+   padding-bottom: 2px;
 }
 
 .title-tile {
@@ -38,24 +43,28 @@ $default-link-hover-color: #23527c;
 }
 
 .tag {
-    border-radius: 5px;
-    color: $darkest-color;
-    padding-top: 4px;
-    padding-bottom: 4px;
-    padding-left: 4px;
-    padding-right: 4px;
-    margin-left: 15px ;
-    background-color: darken(white, 10%);
+    color: $default-text-color;
     display: inline-block;
     font-size: 85%;
-    margin-top: 4px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    padding: 2px 4px 2px 4px;
+    margin: 2px 4px 2px 0px;
 }
 
 .worktype {
-    padding-top: 2px;
-    padding-left:  15px;
     font-size: 85%;
-    padding-bottom: 10px;
+    margin-top: -2px;
+    padding-left: 0px;
+    padding-bottom: 0px;
+}
+
+.type-label {
+    padding: 3px 5px 3px 5px;
+}
+
+.retraction-alert {
+    padding: 2px 8px;
 }
 
 .redirect > a {
@@ -68,41 +77,12 @@ $default-link-hover-color: #23527c;
 }
 
 .redirect {
-    margin-top: 0;
-    margin-bottom: 5px;
+    margin: 0px;
+    padding-right: 0px;
 }
 
-.description {
-    padding-top: 8px;
-    padding-bottom: 8px;
-    padding-left: 15px;
-    padding-right: 15px;
-}
-
-.source-text {
-    color: $darkest-color;
-}
-
-.extra {
-    padding-top: 4px;
-    padding-bottom: 4px;
-    padding-left: 15px;
-}
-
-.filter {
-    cursor: pointer;
-    text-decoration: none;
-}
-
-.typefilter {
-    padding-left: 5px;
-    padding-right: 5px;
-    padding-top: 3px;
-    padding-bottom: 3px;
-}
-
-.retraction-alert {
-    padding: 2px 8px;
+.default-line-padding {
+    padding: 2px 15px 2px 15px;
 }
 
 .default-cursor {

--- a/app/components/search-result/template.hbs
+++ b/app/components/search-result/template.hbs
@@ -69,7 +69,7 @@
     </div>
 {{/if}}
 {{#if (or obj.date_published obj.publishers)}}
-    <div class="row default-line-padding">
+    <div class="row date-line-padding">
         <div class="col-xs-12 default-cursor">
             {{#if obj.date_published}}
                 <span class="pull-left text-data text-left default-cursor">
@@ -94,7 +94,7 @@
     </div>
 {{/if}}
 {{#if obj.date_updated}}
-    <div class="row default-line-padding">
+    <div class="row date-line-padding">
         <div class="col-xs-12 default-cursor">
             <span class="text-muted last-updated">
                 Last updated <span class="text-data">{{dateUpdated}}</span>
@@ -102,7 +102,7 @@
         </div>
     </div>
 {{/if}}
-<div class="row default-line-padding default-cursor">
+<div class="row date-line-padding default-cursor">
     <div class="col-xs-12">
         <span class="text-muted last-updated">
             Last ingested <span class="text-data">{{moment-format obj.date_modified 'MMM DD, YYYY'}}</span> from

--- a/app/components/search-result/template.hbs
+++ b/app/components/search-result/template.hbs
@@ -17,7 +17,7 @@
             </div>
         </div>
         {{#if obj.date_published}}
-            <span class="col-xs-6 pull-right text-data text-right">
+            <span class="col-xs-6 pull-right text-data text-right default-cursor">
                 <span class="text-muted">Published </span>{{datePublished}}
             </span>
         {{/if}}
@@ -34,7 +34,7 @@
         </h4>
     </div>
     {{#if creators}}
-        <div class="row">
+        <div class="row default-cursor">
             <div class="col-xs-12">
                 <span class="pull-left redirect text-left">
                     {{#each creators as |creator index|}}
@@ -54,7 +54,7 @@
     {{/if}}
 </div>
 {{#if abbreviation}}
-    <div class="row description">
+    <div class="row description default-cursor">
         <div class="col-sm-12">
             {{{abbreviation}}}
             {{#if abbreviated}}
@@ -64,12 +64,12 @@
     </div>
 {{/if}}
 {{#if tags}}
-    <div class="row tags">
+    <div class="row default-cursor">
         <div class="col-xs-12">
             {{#each tags as |tag|}}
-                <a class='tag filter' {{action 'addFilter' 'tags' tag}}>
+                <span class='tag'>
                     {{tag}}
-                </a>
+                </span>
             {{/each}}
             {{#if extraTags}}
                 <span class="text-muted">+{{extraTags.length}}</span>
@@ -78,14 +78,14 @@
     </div>
 {{/if}}
 <div class="row extra">
-    <div class="col-xs-6">
+    <div class="col-xs-6 default-cursor">
         {{#if obj.date_updated}}
             <span class="text-muted last-updated">
                 Last updated <span class="text-data">{{dateUpdated}}</span>
             </span>
         {{/if}}
     </div>
-    <div class="col-xs-6 pull-right text-info">
+    <div class="col-xs-6 pull-right text-info default-cursor">
         {{#if obj.publishers}}
             <span class="pull-right published text-right">
                 <span class="text-muted">Published by </span>
@@ -98,7 +98,7 @@
         {{/if}}
     </div>
 </div>
-<div class="row extra">
+<div class="row extra default-cursor">
     <div class="col-xs-12">
         {{#if obj.date_created}}
             <span class="text-muted last-updated">

--- a/app/components/search-result/template.hbs
+++ b/app/components/search-result/template.hbs
@@ -49,7 +49,7 @@
         <div class="col-sm-12">
             {{{abbreviation}}}
             {{#if abbreviated}}
-                <span class="text-muted">...</span>
+                <span class="text-muted description-ellipsis">...</span>
             {{/if}}
         </div>
     </div>

--- a/app/components/search-result/template.hbs
+++ b/app/components/search-result/template.hbs
@@ -19,33 +19,33 @@
             {{/link-to}}
         </h4>
         <div class="col-xs-2 pull-right text-right default-cursor worktype">
-            <span class="typefilter">
+            <span class="type-label">
                 {{type}}
             </span>
         </div>
     </div>
-    {{#if creators}}
-        <div class="row default-cursor">
-            <div class="col-xs-12">
-                <span class="pull-left redirect text-left">
-                    {{#each creators as |creator index|}}
-                        {{#if index}}
-                            -
-                        {{/if}}
-                        {{#link-to 'detail' (slug creator.type) creator.id}}
-                            {{if creator.cited_as creator.cited_as creator.name}}
-                        {{/link-to}}
-                    {{/each}}
-                    {{#if extraCreators}}
-                        <span class="text-muted">+{{extraCreators.length}}</span>
-                    {{/if}}
-                </span>
-            </div>
-        </div>
-    {{/if}}
 </div>
+{{#if creators}}
+    <div class="row default-line-padding default-cursor">
+        <div class="col-xs-12">
+            <span class="pull-left redirect text-left">
+                {{#each creators as |creator index|}}
+                    {{#if index}}
+                        -
+                    {{/if}}
+                    {{#link-to 'detail' (slug creator.type) creator.id}}
+                        {{if creator.cited_as creator.cited_as creator.name}}
+                    {{/link-to}}
+                {{/each}}
+                {{#if extraCreators}}
+                    <span class="text-muted">+{{extraCreators.length}}</span>
+                {{/if}}
+            </span>
+        </div>
+    </div>
+{{/if}}
 {{#if abbreviation}}
-    <div class="row description default-cursor">
+    <div class="row default-line-padding default-cursor">
         <div class="col-sm-12">
             {{{abbreviation}}}
             {{#if abbreviated}}
@@ -55,7 +55,7 @@
     </div>
 {{/if}}
 {{#if tags}}
-    <div class="row default-cursor">
+    <div class="row default-line-padding default-cursor">
         <div class="col-xs-12">
             {{#each tags as |tag|}}
                 <span class='tag'>
@@ -69,7 +69,7 @@
     </div>
 {{/if}}
 {{#if (or obj.date_published obj.publishers)}}
-    <div class="row extra">
+    <div class="row default-line-padding">
         <div class="col-xs-12 default-cursor">
             {{#if obj.date_published}}
                 <span class="pull-left text-data text-left default-cursor">
@@ -94,7 +94,7 @@
     </div>
 {{/if}}
 {{#if obj.date_updated}}
-    <div class="row extra">
+    <div class="row default-line-padding">
         <div class="col-xs-12 default-cursor">
             <span class="text-muted last-updated">
                 Last updated <span class="text-data">{{dateUpdated}}</span>
@@ -102,7 +102,7 @@
         </div>
     </div>
 {{/if}}
-<div class="row extra default-cursor">
+<div class="row default-line-padding default-cursor">
     <div class="col-xs-12">
         <span class="text-muted last-updated">
             Last ingested <span class="text-data">{{moment-format obj.date_modified 'MMM DD, YYYY'}}</span> from

--- a/app/components/search-result/template.hbs
+++ b/app/components/search-result/template.hbs
@@ -8,22 +8,8 @@
             </div>
         </div>
     {{/if}}
-    <div class="row">
-        <div class="col-xs-6 pull-left worktype text-left">
-            <div class="worktype-inner">
-                <a class="filter typefilter" {{action 'addFilter' 'type' obj.type}}>
-                    {{type}}
-                </a>
-            </div>
-        </div>
-        {{#if obj.date_published}}
-            <span class="col-xs-6 pull-right text-data text-right default-cursor">
-                <span class="text-muted">Published </span>{{datePublished}}
-            </span>
-        {{/if}}
-    </div>
     <div class="row title">
-        <h4 class="col-sm-11 redirect">
+        <h4 class="col-xs-10 redirect">
             {{#link-to 'detail' (slug obj.type) obj.id}}
                 {{#if safeTitle}}
                     {{{safeTitle}}}
@@ -32,6 +18,11 @@
                 {{/if}}
             {{/link-to}}
         </h4>
+        <div class="col-xs-2 pull-right text-right default-cursor worktype">
+            <span class="typefilter">
+                {{type}}
+            </span>
+        </div>
     </div>
     {{#if creators}}
         <div class="row default-cursor">
@@ -77,46 +68,57 @@
         </div>
     </div>
 {{/if}}
-<div class="row extra">
-    <div class="col-xs-6 default-cursor">
-        {{#if obj.date_updated}}
+{{#if (or obj.date_published obj.publishers)}}
+    <div class="row extra">
+        <div class="col-xs-12 default-cursor">
+            {{#if obj.date_published}}
+                <span class="pull-left text-data text-left default-cursor">
+                    <span class="text-muted">Published </span>{{datePublished}}
+                </span>
+            {{/if}}
+            {{#if obj.publishers}}
+                <span class="text-info">
+                    {{#if obj.date_published}}
+                        <span class="published text-muted"> by </span>
+                    {{else}}
+                        <span class="text-muted">Published by </span>
+                    {{/if}}
+                    {{#each obj.publishers as |publisher|}}
+                        {{#link-to 'detail' (slug publisher.type) publisher.id}}
+                            {{publisher.name}}
+                        {{/link-to}}
+                    {{/each}}
+                </span>
+            {{/if}}
+        </div>
+    </div>
+{{/if}}
+{{#if obj.date_updated}}
+    <div class="row extra">
+        <div class="col-xs-12 default-cursor">
             <span class="text-muted last-updated">
                 Last updated <span class="text-data">{{dateUpdated}}</span>
             </span>
-        {{/if}}
+        </div>
     </div>
-    <div class="col-xs-6 pull-right text-info default-cursor">
-        {{#if obj.publishers}}
-            <span class="pull-right published text-right">
-                <span class="text-muted">Published by </span>
-                {{#each obj.publishers as |publisher|}}
-                    <a class="filter" {{action 'addFilter' 'publishers' publisher.name}}>
-                        {{publisher.name}}
-                    </a>
-                {{/each}}
-            </span>
-        {{/if}}
-    </div>
-</div>
+{{/if}}
 <div class="row extra default-cursor">
     <div class="col-xs-12">
-        {{#if obj.date_created}}
-            <span class="text-muted last-updated">
-                Last ingested <span class="text-data">{{moment-format obj.date_modified 'MMM DD, YYYY'}}</span> from
-                {{#if (gt obj.sources.length 1)}}
-                    one of
-                {{/if}}
-                <span class="text-info">
-                    {{#each obj.sources as |source index|}}
-                        {{#if index}}
-                            ,
-                        {{/if}}
-                        <a class="filter" {{action 'addFilter' 'sources' source}}>
-                            {{source}}
-                        </a>
-                    {{/each}}
-                </span>
+        <span class="text-muted last-updated">
+            Last ingested <span class="text-data">{{moment-format obj.date_modified 'MMM DD, YYYY'}}</span> from
+            {{#if (gt obj.sources.length 1)}}
+                one of
+            {{/if}}
+            <span class="text-muted">
+                {{#each obj.sources as |source index|}}
+                    {{#if index}}
+                        ,
+                    {{/if}}
+                    <span class="source-text">
+                        {{source}}
+                    </span>
+                {{/each}}
             </span>
-        {{/if}}
+        </span>
     </div>
 </div>

--- a/app/components/sortby-dropdown/template.hbs
+++ b/app/components/sortby-dropdown/template.hbs
@@ -1,10 +1,10 @@
-<button class="btn btn-select dropdown-toggle discover-filter-facets align-left display-text"
+<button class="btn btn-select discover-btn-select dropdown-toggle discover-filter-facets align-left display-text"
     type="button" id="sortBy" data-toggle="dropdown"
     aria-haspopup="true" aria-expanded="true">
     <span class="fa fa-sort pull-right sort-icon"></span>
     Sort by: {{sortDisplay}}
 </button>
-<ul class="dropdown-menu" aria-labelledby="sortBy">
+<ul class="dropdown-menu discover-dropdown-menu" aria-labelledby="sortBy">
     {{#each sortOptions as |option|}}
         <li class="dropdown-cursor">
             <a {{action "select" option.sortBy option.display}}>{{option.display}}</a>

--- a/app/components/sortby-dropdown/template.hbs
+++ b/app/components/sortby-dropdown/template.hbs
@@ -1,4 +1,4 @@
-<button class="btn btn-select discover-btn-select dropdown-toggle discover-filter-facets align-left display-text"
+<button class="discover-btn-select dropdown-toggle discover-filter-facets align-left display-text"
     type="button" id="sortBy" data-toggle="dropdown"
     aria-haspopup="true" aria-expanded="true">
     <span class="fa fa-sort pull-right sort-icon"></span>

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -1,3 +1,4 @@
+
 import _ from 'lodash/lodash';
 import moment from 'moment';
 import Ember from 'ember';
@@ -43,10 +44,8 @@ export default ApplicationController.extend({
 
     results: Ember.ArrayProxy.create({ content: [] }),
     loading: true,
-    eventsLastUpdated: Date().toString(),
     numberOfResults: 0,
     took: 0,
-    numberOfSources: 0,
     types: {},
 
     totalPages: Ember.computed('numberOfResults', 'size', function() {
@@ -123,7 +122,6 @@ export default ApplicationController.extend({
         }).then((json) => {
             this.setProperties({
                 numberOfEvents: json.hits.total,
-                numberOfSources: json.aggregations.sources.value
             });
         });
     },

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -326,7 +326,7 @@ export default ApplicationController.extend({
     }),
 
     scrollToResults() {
-        Ember.$('html, body').scrollTop(Ember.$('.results-top').position().top);
+        Ember.$('html, body').scrollTop(Ember.$('.discover-search-section').position().top);
     },
 
     actions: {

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -21,6 +21,8 @@ export default ApplicationController.extend({
         return allParams;
     }),
 
+    placeholder: 'Search scholarly works',
+
     page: 1,
     size: 10,
     q: '',

--- a/app/routes/discover.js
+++ b/app/routes/discover.js
@@ -17,8 +17,10 @@ export default Ember.Route.extend(RouteHistoryMixin, {
             controller.set('contributors', '');
             controller.set('start', '');
             controller.set('end', '');
+            controller.set('date', 'date_modified');
             controller.set('type', '');
             controller.set('sort', '');
+            controller.set('sortDisplay', 'Relevance');
             controller.set('facetFilters', Ember.Object.create());
             controller.set('firstLoad', true);
         }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -268,6 +268,10 @@ hr.divider {
     }
 }
 
+.tooltip-helper:focus {
+    outline: none;
+}
+
 .dropdown-menu {
     background-color: white;
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -115,7 +115,6 @@
 .share-search {
 
     .search-button {
-        margin-left: -20px;
         margin-top: 5px;
         font-size: 150%;
     }
@@ -133,6 +132,7 @@
 $discover-background-color: lighten(lightslategray, 45%);
 $discover-result-background-color: white;
 $text-muted: #777777;
+$xs-width: 768px;
 
 // light gray
 $facet-separator-color: #AAA;
@@ -146,11 +146,18 @@ $default-text-color-active: #337ab7;
 $default-link-hover-color: #23527c;
 
 
+.discover-flex-search-container {
+    display: flex;
+    justify-content: center;
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
 .discover-search-section {
     padding-bottom: 15px;
     padding-top: 30px;
-    padding-left: 0px;
-    padding-right: 0px;
+    padding-left: 15px;
+    padding-right: 15px;
     background-color: $discover-background-color;
 }
 
@@ -161,6 +168,29 @@ $default-link-hover-color: #23527c;
     width: 100%;
 }
 
+.discover-search-bar {
+    padding-left: 15px;
+}
+
+.discover-search-icons {
+    padding: 0px;
+
+    > a:hover {
+        text-decoration: none;
+    }
+}
+
+@media (max-width: $xs-width) {
+    .discover-search-block {
+        padding-right: 15px;
+    }
+
+    .discover-flex-search-container {
+        padding-left: 15px;
+        padding-right: 15px;
+    }
+}
+
 .discover-flex-container {
     display: flex;
     flex-wrap: nowrap;
@@ -169,15 +199,14 @@ $default-link-hover-color: #23527c;
     background-color: $discover-background-color;
 }
 
-.discover-flex-search-container {
-    display: flex;
-    justify-content: center;
-}
-
 .discover-sidebar {
     width: 220px;
     padding-left: 20px;
     margin-top: -26px;
+}
+
+.discover-sidebar-xs {
+    background-color: $discover-background-color;
 }
 
 .discover-main-content {
@@ -258,6 +287,12 @@ $default-link-hover-color: #23527c;
     padding-bottom: 8px;
 }
 
+@media (max-width: $xs-width) {
+    .reset-filters-section {
+        width: 100%;
+    }
+}
+
 .reset-filters-btn, .reset-filters-btn:focus {
     color: $default-text-color;
     background-color: $discover-background-color;
@@ -287,12 +322,6 @@ $default-link-hover-color: #23527c;
 
 .discover-btn-select:active {
     color: $default-text-color-active;
-}
-
-.discover-search-icons {
-    > a:hover {
-        text-decoration: none;
-    }
 }
 
 .search-result-block {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -134,17 +134,28 @@
     padding-top: 30px;
     padding-left: 0px;
     padding-right: 0px;
-    max-width: 1020px;
+    // test
+    background-color: lighten(lightslategray, 45%)
 }
 
 .discover-search-block {
-    margin-right: 220px;
+    max-width: 1020px;
+    padding-right: 220px;
+    padding-left: 0px;
+    width: 100%;
 }
 
 .discover-flex-container {
     display: flex;
     flex-wrap: nowrap;
     flex-direction: row;
+    justify-content: center;
+    // test
+    background-color: lighten(lightslategray, 45%)
+}
+
+.discover-flex-search-container {
+    display: flex;
     justify-content: center;
 }
 
@@ -206,7 +217,8 @@
 
 .btn-select {
     color: black;
-    background-color: white;
+    // test
+    background-color: lighten(lightslategray, 45%);
     height: 33px ;
     font-size: 14px ;
     padding: 0px;
@@ -217,7 +229,9 @@
     margin-bottom: 20px;
     padding-bottom: 20px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
-    background-color: darken(white, 2%);
+    // test
+    background-color: white;
+    // background-color: darken(white, 2%);
 }
 
 .discover-results-found {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -132,6 +132,8 @@
 $discover-background-color: lighten(lightslategray, 45%);
 $discover-result-background-color: white;
 $darkest-color: #222;
+$gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
+$facet-separator-color: #AAA;
 
 .discover-search-section {
     padding-bottom: 15px;
@@ -211,11 +213,19 @@ $darkest-color: #222;
     padding-top: 8px;
 }
 
-.clear-filters, .clear-filters:focus, .clear-filters:hover, .clear-filters:active {
-    background-color: white;
+.reset-filters-section {
+    border-top: 1px solid transparent;
+    border-color: $facet-separator-color;
+    width: 200px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+.reset-filters-btn, .reset-filters-btn:focus, .reset-filters-btn:hover, .reset-filters-btn:active {
+    background-color: $discover-background-color;
     color: $darkest-color;
-    border: 1px solid transparent;
-    border-color: #ccc;
+    border: none;
+    padding-left: 0px;
 }
 
 .discover-btn-select {
@@ -264,7 +274,7 @@ $darkest-color: #222;
             color: $darkest-color;
         }
         > a:hover, a:focus {
-            background-color: #4f5050;
+            background-color: $gray-color;
             background-image: none;
             color: white;
         }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -134,6 +134,9 @@ $discover-result-background-color: white;
 $darkest-color: #222;
 $gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
 $facet-separator-color: #AAA;
+$default-text-color: #4f5050;
+$default-text-color-active: #4285f4;
+$text-muted: #777777;
 
 .discover-search-section {
     padding-bottom: 15px;
@@ -166,7 +169,7 @@ $facet-separator-color: #AAA;
 .discover-sidebar {
     width: 220px;
     padding-left: 20px;
-    margin-top: -40px;
+    margin-top: -26px;
 }
 
 .discover-main-content {
@@ -181,6 +184,28 @@ $facet-separator-color: #AAA;
 
 .discover-font {
     font-size:75%;
+    > i > a {
+        color: $default-text-color;
+    }
+
+    > i > a:hover {
+        color: $darkest-color;
+        text-decoration: none;
+    }
+
+    > i > a:active {
+        color: $default-text-color-active;
+    }
+
+    > i > a:focus {
+        text-decoration: none;
+        outline: none;
+    }
+
+    > i > .elasticsearch-link {
+        color: $default-text-color-active;
+    }
+
 }
 
 .discover-filter-facets {
@@ -221,20 +246,41 @@ $facet-separator-color: #AAA;
     padding-bottom: 8px;
 }
 
-.reset-filters-btn, .reset-filters-btn:focus, .reset-filters-btn:hover, .reset-filters-btn:active {
+.reset-filters-btn, .reset-filters-btn:focus {
+    color: $default-text-color;
     background-color: $discover-background-color;
-    color: $darkest-color;
     border: none;
     padding-left: 0px;
+    outline: none;
+}
+
+.reset-filters-btn:hover {
+    color: $darkest-color;
+}
+
+.reset-filters-btn:active {
+    color: $default-text-color-active;
 }
 
 .discover-btn-select {
-    color: $darkest-color;
     background-color: $discover-background-color;
-    height: 33px ;
-    font-size: 14px ;
+    color: $default-text-color;
     padding: 0px;
-    padding-right: 5px;
+    border-width: 0px;
+}
+
+.discover-btn-select:hover {
+    color: $darkest-color;
+}
+
+.discover-btn-select:active {
+    color: $default-text-color-active;
+}
+
+.discover-search-icons {
+    > a:hover {
+        text-decoration: none;
+    }
 }
 
 .search-result-block {
@@ -245,7 +291,7 @@ $facet-separator-color: #AAA;
 }
 
 .discover-results-found {
-    color: $darkest-color;
+    color: $default-text-color;
 }
 
 .tooltip-helper {
@@ -271,7 +317,7 @@ $facet-separator-color: #AAA;
         cursor: pointer;
         cursor: hand;
         > a {
-            color: $darkest-color;
+            color: $default-text-color;
         }
         > a:hover, a:focus {
             background-color: $gray-color;
@@ -326,7 +372,7 @@ $facet-separator-color: #AAA;
 }
 
 .detail-back-arrow {
-    color: $darkest-color;
+    color: $default-text-color;
     cursor: pointer;
 }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -129,13 +129,16 @@
 
 /* Discover */
 
+$discover-background-color: lighten(lightslategray, 45%);
+$discover-result-background-color: white;
+$darkest-color: #222;
+
 .discover-search-section {
     padding-bottom: 15px;
     padding-top: 30px;
     padding-left: 0px;
     padding-right: 0px;
-    // test
-    background-color: lighten(lightslategray, 45%)
+    background-color: $discover-background-color;
 }
 
 .discover-search-block {
@@ -150,8 +153,7 @@
     flex-wrap: nowrap;
     flex-direction: row;
     justify-content: center;
-    // test
-    background-color: lighten(lightslategray, 45%)
+    background-color: $discover-background-color;
 }
 
 .discover-flex-search-container {
@@ -167,6 +169,7 @@
 
 .discover-main-content {
     width: 100%;
+    padding-bottom: 15px;
 }
 
 .no-results {
@@ -210,15 +213,14 @@
 
 .clear-filters, .clear-filters:focus, .clear-filters:hover, .clear-filters:active {
     background-color: white;
-    color: black;
+    color: $darkest-color;
     border: 1px solid transparent;
     border-color: #ccc;
 }
 
-.btn-select {
-    color: black;
-    // test
-    background-color: lighten(lightslategray, 45%);
+.discover-btn-select {
+    color: $darkest-color;
+    background-color: $discover-background-color;
     height: 33px ;
     font-size: 14px ;
     padding: 0px;
@@ -229,14 +231,53 @@
     margin-bottom: 20px;
     padding-bottom: 20px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
-    // test
-    background-color: white;
-    // background-color: darken(white, 2%);
+    background-color: $discover-result-background-color;
 }
 
 .discover-results-found {
-    color: black;
+    color: $darkest-color;
 }
+
+.tooltip-helper {
+    padding-left: 4px;
+    width: 100%;
+
+    > .help-icon {
+        height: 100%;
+        align-items: center;
+        display: flex;
+        padding-right: 3px;
+    }
+}
+
+.tooltip-helper:focus {
+    outline: none;
+}
+
+.discover-dropdown-menu {
+    background-color: white;
+
+    > .dropdown-cursor {
+        cursor: pointer;
+        cursor: hand;
+        > a {
+            color: $darkest-color;
+        }
+        > a:hover, a:focus {
+            background-color: #4f5050;
+            background-image: none;
+            color: white;
+        }
+    }
+}
+
+.restrict-width {
+    max-width: 800px;
+    padding-left: 0px;
+    padding-right: 0px;
+}
+
+/* Detail */
 
 .title-container {
     padding-top: 60px;
@@ -270,58 +311,12 @@
     }
 }
 
-hr.divider {
-    margin-top: 0px;
-    margin-bottom: 10px;
-}
-
-.tooltip-helper {
-    padding-left: 4px;
-    width: 100%;
-
-    > .help-icon {
-        height: 100%;
-        align-items: center;
-        display: flex;
-        padding-right: 3px;
-    }
-}
-
-.tooltip-helper:focus {
-    outline: none;
-}
-
-.dropdown-menu {
-    background-color: white;
-
-    > .dropdown-cursor {
-        cursor: pointer;
-        cursor: hand;
-        > a {
-            color: black;
-        }
-        > a:hover, a:focus {
-            background-color: dimgray;
-            background-image: none;
-            color: white;
-        }
-    }
-}
-
-.restrict-width {
-    max-width: 800px;
-    padding-left: 0px;
-    padding-right: 0px;
-}
-
-/* Detail */
-
 .detail-back-arrow-block {
     text-align: left;
 }
 
 .detail-back-arrow {
-    color: black;
+    color: $darkest-color;
     cursor: pointer;
 }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -129,15 +129,22 @@
 
 /* Discover */
 
+// lightslategray is a blue-gray color
 $discover-background-color: lighten(lightslategray, 45%);
 $discover-result-background-color: white;
-$darkest-color: #222;
-$gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
-$facet-separator-color: #AAA;
-$default-text-color: #4f5050;
-$default-text-color-active: #337ab7;
-$default-link-hover-color: #23527c;
 $text-muted: #777777;
+
+// light gray
+$facet-separator-color: #AAA;
+// minumum gray contrast that meets WCAG 2.0 AA/AAA standards
+$default-text-color: #4f5050;
+// use for hover on buttons and dark text
+$darkest-color: #222;
+// bright blue
+$default-text-color-active: #337ab7;
+// dark blue
+$default-link-hover-color: #23527c;
+
 
 .discover-search-section {
     padding-bottom: 15px;
@@ -325,7 +332,7 @@ $text-muted: #777777;
             color: $default-text-color;
         }
         > a:hover, a:focus {
-            background-color: $gray-color;
+            background-color: $default-text-color;
             background-image: none;
             color: white;
         }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -113,6 +113,7 @@
 }
 
 .share-search {
+
     .search-button {
         margin-left: -20px;
         margin-top: 5px;
@@ -128,6 +129,18 @@
 
 /* Discover */
 
+.discover-search-section {
+    padding-bottom: 15px;
+    padding-top: 30px;
+    padding-left: 0px;
+    padding-right: 0px;
+    max-width: 1020px;
+}
+
+.discover-search-block {
+    margin-right: 220px;
+}
+
 .discover-flex-container {
     display: flex;
     flex-wrap: nowrap;
@@ -137,15 +150,8 @@
 
 .discover-sidebar {
     width: 220px;
-    padding-right: 20px;
-}
-
-@media (min-width: 1300px) {
-    .discover-sidebar {
-        width: 220px;
-        padding-right: 20px;
-        margin-left: -220px;
-    }
+    padding-left: 20px;
+    margin-top: -40px;
 }
 
 .discover-main-content {
@@ -157,9 +163,8 @@
     color: dimgray;
 }
 
-.discover-font-margin {
+.discover-font {
     font-size:75%;
-    margin-top:15px;
 }
 
 .discover-filter-facets {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -135,7 +135,8 @@ $darkest-color: #222;
 $gray-color: #4f5050;  // minumum contrast that meets WCAG 2.0 AA/AAA standards
 $facet-separator-color: #AAA;
 $default-text-color: #4f5050;
-$default-text-color-active: #4285f4;
+$default-text-color-active: #337ab7;
+$default-link-hover-color: #23527c;
 $text-muted: #777777;
 
 .discover-search-section {
@@ -204,6 +205,10 @@ $text-muted: #777777;
 
     > i > .elasticsearch-link {
         color: $default-text-color-active;
+    }
+
+    > i > .elasticsearch-link:hover {
+        color: $default-link-hover-color;
     }
 
 }

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -1,8 +1,6 @@
-<div class="container restrict-width">
-    <br>
-    <br>
-    <div class="row share-search">
-        <div class="col-xs-10 col-xs-offset-1">
+<div class="container-fluid discover-search-section">
+    <div class="row share-search discover-search-block">
+        <div class="col-xs-11">
             {{input class="form-control" value=q key-up='typing'}}
         </div>
         <div class="col-xs-1">
@@ -14,34 +12,34 @@
             </a>
         </div>
     </div>
-    <div class="row">
-        <div class="col-sm-10 col-sm-offset-1">
+    <div class="row discover-search-block">
+        <div class="col-sm-11">
             <div class="row">
-              <div class="col-xs-12 text-muted">
+              <div class="col-xs-8 text-muted">
                   <small>Found {{locale-string numberOfResults}} events in {{took}} seconds</small>
               </div>
+              {{#if queryBody}}
+                <div class="col-xs-4 text-right discover-font">
+                    <i>
+                        <a{{action 'toggleCollapsedQueryBody'}} href="#">
+                            View query body
+                            {{#if collapsedQueryBody}}
+                                {{fa-icon 'caret-up'}}
+                            {{else}}
+                                {{fa-icon 'caret-down'}}
+                            {{/if}}
+                        </a>
+                    </i>
+                </div>
+            {{/if}}
             </div>
         </div>
     </div>
-    {{#if queryBody}}
-        <div class="row text-center discover-font-margin">
-            <i>
-                <a{{action 'toggleCollapsedQueryBody'}} href="#">
-                    View query body
-                    {{#if collapsedQueryBody}}
-                        {{fa-icon 'caret-up'}}
-                    {{else}}
-                        {{fa-icon 'caret-down'}}
-                    {{/if}}
-                </a>
-            </i>
-        </div>
-    {{/if}}
     {{#bs-collapse collapsed=collapsedQueryBody}}
         <div id="queryBody" class="row">
             <div class="col-sm-10 col-sm-offset-1">
                 <div class="row">
-                    <div class="text-center discover-font-margin">
+                    <div class="text-center discover-font">
                         <i>Search API: <a href={{searchUrl}}>{{searchUrl}}</a></i>
                     </div>
                     <div class="col-sm-10 col-sm-offset-1">
@@ -54,7 +52,7 @@
             </div>
         </div>
     {{/bs-collapse}}
-    <div class="row">
+   {{!--  <div class="row">
         <div class="col-xs-6 text-left">
             <button {{action 'clearFilters'}} class='btn clear-filters'>
                 Clear filters
@@ -73,7 +71,7 @@
                 {{/if}}
             </div>
         {{/if}}
-    </div>
+    </div> --}}
     <div class="row visible-xs">
         <div class="col-xs-12 discover-filter-list">
             {{#each facetStatesArray as |filter|}}
@@ -88,7 +86,7 @@
         </div>
     </div>
     <div class="row visible-xs">
-        <div class="col-xs-12 text-right discover-font-margin">
+        <div class="col-xs-12 text-right discover-font">
             <i>
                 <a{{action 'toggleCollapsedFilters'}} href="#">
                     View filter options
@@ -101,7 +99,6 @@
             </i>
         </div>
     </div>
-    <hr class='results-top'>
 </div>
 <div class="container-fluid">
     <div class="row">
@@ -125,6 +122,22 @@
             </div>
         {{/if}}
         <div class='col-xs-12 discover-flex-container'>
+            <div class='discover-main-content restrict-width'>
+                {{#if loading}}
+                    {{loading-bars}}
+                {{else if queryError}}
+                    {{query-syntax}}
+                {{else if noResultsMessage}}
+                    <div class="text-center no-results">{{noResultsMessage}}</div>
+                {{else}}
+                    {{#each results as |obj|}}
+                        {{search-result addFilter='addFilter' obj=obj}}
+                    {{/each}}
+                    <div class="pull-left text-left">
+                        {{page-controls page=page clampedPages=clampedPages loadPage=(action 'loadPage')}}
+                    </div>
+                {{/if}}
+            </div>
             {{#if (not media.isExtraSmall)}}
                 <div class='discover-sidebar hidden-xs'>
                     {{sortby-dropdown
@@ -142,22 +155,6 @@
                     }}
                 </div>
             {{/if}}
-            <div class='discover-main-content restrict-width'>
-                {{#if loading}}
-                    {{loading-bars}}
-                {{else if queryError}}
-                    {{query-syntax}}
-                {{else if noResultsMessage}}
-                    <div class="text-center no-results">{{noResultsMessage}}</div>
-                {{else}}
-                    {{#each results as |obj|}}
-                        {{search-result addFilter='addFilter' obj=obj}}
-                    {{/each}}
-                    <div class="pull-right text-right">
-                        {{page-controls page=page clampedPages=clampedPages loadPage=(action 'loadPage')}}
-                    </div>
-                {{/if}}
-            </div>
         </div>
     </div>
     <br>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -3,7 +3,7 @@
         <div class="col-xs-12 discover-search-block">
             <div class="row share-search">
                 <div class="col-xs-11 discover-search-bar">
-                    {{input class="form-control" value=q key-up='typing'}}
+                    {{input class="form-control" value=q key-up='typing' placeholder=placeholder}}
                 </div>
                 <div class="col-xs-1 discover-search-icons">
                     <a href="" {{action 'search'}}>
@@ -18,7 +18,7 @@
                 <div class="col-xs-11 discover-search-bar">
                     <div class="row">
                       <div class="col-xs-8 text-muted">
-                          <small>Found {{locale-string numberOfResults}} events in {{took}} seconds</small>
+                          <small>Found {{locale-string numberOfResults}} works in {{took}} seconds</small>
                       </div>
                       {{#if queryBody}}
                         <div class="col-xs-4 text-right discover-font">

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -54,14 +54,6 @@
                     </div>
                 </div>
             {{/bs-collapse}}
-           {{!--  <div class="row">
-                <div class="col-xs-6 text-left">
-                    <button {{action 'clearFilters'}} class='btn clear-filters'>
-                        Clear filters
-                        <i class="fa fa-times text-danger"></i>
-                    </button>
-                </div>
-            </div> --}}
             <div class="row visible-xs">
                 <div class="col-xs-12 discover-filter-list">
                     {{#each facetStatesArray as |filter|}}
@@ -102,6 +94,7 @@
                         sortDisplay=sortDisplay
                         selectSortOption=(action 'selectSortOption')
                     }}
+                    {{!-- replace with clear filter button --}}
                     {{faceted-search
                         onChange='filtersChanged'
                         updateParams='updateParams'
@@ -142,6 +135,16 @@
                         sortDisplay=sortDisplay
                         selectSortOption=(action 'selectSortOption')
                     }}
+                    <div class="row">
+                        <div class="col-xs-12 text-left">
+                            <div class="reset-filters-section">
+                                <button {{action 'clearFilters'}} class='btn reset-filters-btn'>
+                                    Reset all filters
+                                    <i class="fa fa-times text-danger"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                     {{faceted-search
                         onChange='filtersChanged'
                         updateParams='updateParams'

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -2,7 +2,7 @@
     <div class="row discover-flex-search-container">
         <div class="col-xs-12 discover-search-block">
             <div class="row share-search">
-                <div class="col-xs-11">
+                <div class="col-xs-11 discover-search-bar">
                     {{input class="form-control" value=q key-up='typing'}}
                 </div>
                 <div class="col-xs-1 discover-search-icons">
@@ -15,7 +15,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-11">
+                <div class="col-xs-11 discover-search-bar">
                     <div class="row">
                       <div class="col-xs-8 text-muted">
                           <small>Found {{locale-string numberOfResults}} events in {{took}} seconds</small>
@@ -68,7 +68,7 @@
                 </div>
             </div>
             <div class="row visible-xs">
-                <div class="col-xs-12 text-right discover-font">
+                <div class="col-xs-12 text-left discover-font">
                     <i>
                         <a{{action 'toggleCollapsedFilters'}} href="#">
                             View filter options
@@ -87,14 +87,23 @@
 <div class="container-fluid">
     <div class="row">
         {{#if media.isExtraSmall}}
-            <div class='col-xs-12 visible-xs'>
+            <div class='col-xs-12 visible-xs discover-sidebar-xs'>
                 {{#bs-collapse collapsed=collapsedFilters}}
                     {{sortby-dropdown
                         sortOptions=sortOptions
                         sortDisplay=sortDisplay
                         selectSortOption=(action 'selectSortOption')
                     }}
-                    {{!-- replace with clear filter button --}}
+                    <div class="row">
+                        <div class="col-xs-12 text-left">
+                            <div class="reset-filters-section">
+                                <button {{action 'clearFilters'}} class='reset-filters-btn'>
+                                    Reset all filters
+                                    <i class="fa fa-times text-danger"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                     {{faceted-search
                         onChange='filtersChanged'
                         updateParams='updateParams'

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -61,18 +61,6 @@
                         <i class="fa fa-times text-danger"></i>
                     </button>
                 </div>
-                {{#if (not noResultsMessage)}}
-                    <div class="col-sm-6 pull-right text-right">
-                        <div>
-                            {{page-controls page=page clampedPages=clampedPages loadPage=(action 'loadPageNoScroll')}}
-                        </div>
-                        {{#if hiddenPages}}
-                            <div style="color:gray">
-                                {{locale-string hiddenPages}} additional pages not shown
-                            </div>
-                        {{/if}}
-                    </div>
-                {{/if}}
             </div> --}}
             <div class="row visible-xs">
                 <div class="col-xs-12 discover-filter-list">
@@ -139,6 +127,11 @@
                     {{/each}}
                     <div class="pull-left text-left">
                         {{page-controls page=page clampedPages=clampedPages loadPage=(action 'loadPage')}}
+                        {{#if hiddenPages}}
+                            <div style="color:gray">
+                                {{locale-string hiddenPages}} additional pages not shown
+                            </div>
+                        {{/if}}
                     </div>
                 {{/if}}
             </div>
@@ -161,5 +154,4 @@
             {{/if}}
         </div>
     </div>
-    <br>
 </div>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -5,7 +5,7 @@
                 <div class="col-xs-11">
                     {{input class="form-control" value=q key-up='typing'}}
                 </div>
-                <div class="col-xs-1">
+                <div class="col-xs-1 discover-search-icons">
                     <a href="" {{action 'search'}}>
                         {{fa-icon 'search' class='search-button' title='Search'}}
                     </a>
@@ -39,12 +39,12 @@
             </div>
             {{#bs-collapse collapsed=collapsedQueryBody}}
                 <div id="queryBody" class="row">
-                    <div class="col-sm-10 col-sm-offset-1">
+                    <div class="col-xs-12">
                         <div class="row">
-                            <div class="text-center discover-font">
-                                <i>Search API: <a href={{searchUrl}}>{{searchUrl}}</a></i>
+                            <div class=" col-xs-11 text-left discover-font">
+                                <i>Search API: <a class="elasticsearch-link" href={{searchUrl}}>{{searchUrl}}</a></i>
                             </div>
-                            <div class="col-sm-10 col-sm-offset-1">
+                            <div class="col-xs-11">
                                 {{json-pretty
                                     obj=displayQueryBody
                                     shouldHighlight=true
@@ -138,7 +138,7 @@
                     <div class="row">
                         <div class="col-xs-12 text-left">
                             <div class="reset-filters-section">
-                                <button {{action 'clearFilters'}} class='btn reset-filters-btn'>
+                                <button {{action 'clearFilters'}} class='reset-filters-btn'>
                                     Reset all filters
                                     <i class="fa fa-times text-danger"></i>
                                 </button>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -1,29 +1,98 @@
 <div class="container-fluid discover-search-section">
-    <div class="row share-search discover-search-block">
-        <div class="col-xs-11">
-            {{input class="form-control" value=q key-up='typing'}}
-        </div>
-        <div class="col-xs-1">
-            <a href="" {{action 'search'}}>
-                {{fa-icon 'search' class='search-button' title='Search'}}
-            </a>
-            <a href={{atomFeedUrl}}>
-                {{fa-icon 'feed' class='feed-button' title='Atom feed for this search'}}
-            </a>
-        </div>
-    </div>
-    <div class="row discover-search-block">
-        <div class="col-sm-11">
+    <div class="row discover-flex-search-container">
+        <div class="col-xs-12 discover-search-block">
+            <div class="row share-search">
+                <div class="col-xs-11">
+                    {{input class="form-control" value=q key-up='typing'}}
+                </div>
+                <div class="col-xs-1">
+                    <a href="" {{action 'search'}}>
+                        {{fa-icon 'search' class='search-button' title='Search'}}
+                    </a>
+                    <a href={{atomFeedUrl}}>
+                        {{fa-icon 'feed' class='feed-button' title='Atom feed for this search'}}
+                    </a>
+                </div>
+            </div>
             <div class="row">
-              <div class="col-xs-8 text-muted">
-                  <small>Found {{locale-string numberOfResults}} events in {{took}} seconds</small>
-              </div>
-              {{#if queryBody}}
-                <div class="col-xs-4 text-right discover-font">
+                <div class="col-sm-11">
+                    <div class="row">
+                      <div class="col-xs-8 text-muted">
+                          <small>Found {{locale-string numberOfResults}} events in {{took}} seconds</small>
+                      </div>
+                      {{#if queryBody}}
+                        <div class="col-xs-4 text-right discover-font">
+                            <i>
+                                <a{{action 'toggleCollapsedQueryBody'}} href="#">
+                                    View query body
+                                    {{#if collapsedQueryBody}}
+                                        {{fa-icon 'caret-up'}}
+                                    {{else}}
+                                        {{fa-icon 'caret-down'}}
+                                    {{/if}}
+                                </a>
+                            </i>
+                        </div>
+                    {{/if}}
+                    </div>
+                </div>
+            </div>
+            {{#bs-collapse collapsed=collapsedQueryBody}}
+                <div id="queryBody" class="row">
+                    <div class="col-sm-10 col-sm-offset-1">
+                        <div class="row">
+                            <div class="text-center discover-font">
+                                <i>Search API: <a href={{searchUrl}}>{{searchUrl}}</a></i>
+                            </div>
+                            <div class="col-sm-10 col-sm-offset-1">
+                                {{json-pretty
+                                    obj=displayQueryBody
+                                    shouldHighlight=true
+                                }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {{/bs-collapse}}
+           {{!--  <div class="row">
+                <div class="col-xs-6 text-left">
+                    <button {{action 'clearFilters'}} class='btn clear-filters'>
+                        Clear filters
+                        <i class="fa fa-times text-danger"></i>
+                    </button>
+                </div>
+                {{#if (not noResultsMessage)}}
+                    <div class="col-sm-6 pull-right text-right">
+                        <div>
+                            {{page-controls page=page clampedPages=clampedPages loadPage=(action 'loadPageNoScroll')}}
+                        </div>
+                        {{#if hiddenPages}}
+                            <div style="color:gray">
+                                {{locale-string hiddenPages}} additional pages not shown
+                            </div>
+                        {{/if}}
+                    </div>
+                {{/if}}
+            </div> --}}
+            <div class="row visible-xs">
+                <div class="col-xs-12 discover-filter-list">
+                    {{#each facetStatesArray as |filter|}}
+                        {{#if (and filter.key (not-eq key 'date'))}}
+                            {{#each filter.value as |value|}}
+                                <a class='discover-filter-block' {{action 'removeFilter' filter.key value}}>
+                                    {{value}} {{fa-icon 'times'}}
+                                </a>
+                            {{/each}}
+                        {{/if}}
+                    {{/each}}
+                </div>
+            </div>
+            <div class="row visible-xs">
+                <div class="col-xs-12 text-right discover-font">
                     <i>
-                        <a{{action 'toggleCollapsedQueryBody'}} href="#">
-                            View query body
-                            {{#if collapsedQueryBody}}
+                        <a{{action 'toggleCollapsedFilters'}} href="#">
+                            View filter options
+                            {{#if collapsedFilters}}
                                 {{fa-icon 'caret-up'}}
                             {{else}}
                                 {{fa-icon 'caret-down'}}
@@ -31,72 +100,7 @@
                         </a>
                     </i>
                 </div>
-            {{/if}}
             </div>
-        </div>
-    </div>
-    {{#bs-collapse collapsed=collapsedQueryBody}}
-        <div id="queryBody" class="row">
-            <div class="col-sm-10 col-sm-offset-1">
-                <div class="row">
-                    <div class="text-center discover-font">
-                        <i>Search API: <a href={{searchUrl}}>{{searchUrl}}</a></i>
-                    </div>
-                    <div class="col-sm-10 col-sm-offset-1">
-                        {{json-pretty
-                            obj=displayQueryBody
-                            shouldHighlight=true
-                        }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    {{/bs-collapse}}
-   {{!--  <div class="row">
-        <div class="col-xs-6 text-left">
-            <button {{action 'clearFilters'}} class='btn clear-filters'>
-                Clear filters
-                <i class="fa fa-times text-danger"></i>
-            </button>
-        </div>
-        {{#if (not noResultsMessage)}}
-            <div class="col-sm-6 pull-right text-right">
-                <div>
-                    {{page-controls page=page clampedPages=clampedPages loadPage=(action 'loadPageNoScroll')}}
-                </div>
-                {{#if hiddenPages}}
-                    <div style="color:gray">
-                        {{locale-string hiddenPages}} additional pages not shown
-                    </div>
-                {{/if}}
-            </div>
-        {{/if}}
-    </div> --}}
-    <div class="row visible-xs">
-        <div class="col-xs-12 discover-filter-list">
-            {{#each facetStatesArray as |filter|}}
-                {{#if (and filter.key (not-eq key 'date'))}}
-                    {{#each filter.value as |value|}}
-                        <a class='discover-filter-block' {{action 'removeFilter' filter.key value}}>
-                            {{value}} {{fa-icon 'times'}}
-                        </a>
-                    {{/each}}
-                {{/if}}
-            {{/each}}
-        </div>
-    </div>
-    <div class="row visible-xs">
-        <div class="col-xs-12 text-right discover-font">
-            <i>
-                <a{{action 'toggleCollapsedFilters'}} href="#">
-                    View filter options
-                    {{#if collapsedFilters}}
-                        {{fa-icon 'caret-up'}}
-                    {{else}}
-                        {{fa-icon 'caret-down'}}
-                    {{/if}}
-                </a>
-            </i>
         </div>
     </div>
 </div>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -17,14 +17,8 @@
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1">
             <div class="row">
-              <div class="text-muted col-sm-4 hidden-xs">
-                  <small>{{locale-string numberOfEvents}} events as of {{moment-format eventsLastUpdated 'MMM D, YYYY' 'ddd MMM DD YYYY HH:mm:ss'}}</small>
-              </div>
-              <div class="col-sm-4 col-xs-12 text-center discover-results-found">
+              <div class="col-xs-12 text-muted">
                   <small>Found {{locale-string numberOfResults}} events in {{took}} seconds</small>
-              </div>
-              <div class="text-muted col-sm-4 hidden-xs text-right">
-                  <small>Aggregating {{locale-string numberOfSources}} sources</small>
               </div>
             </div>
         </div>


### PR DESCRIPTION
## Purpose

Make the discover page consistent.

## Changes

Before:
![screen shot 2017-04-17 at 12 13 17 pm](https://cloud.githubusercontent.com/assets/7131985/25094941/4cb64382-2367-11e7-9d0c-384dc5cd4ded.png)

After:
![screen shot 2017-04-17 at 12 34 08 pm](https://cloud.githubusercontent.com/assets/7131985/25095572/487b5462-236a-11e7-92ef-d560b9f71fd5.png)

#### Nav bar
* restrict width to max page width

#### Top search bar
* left justified with results instead of centered
* add placeholder in search bar
* remove all results and aggregated sources from under search bar
* pagination is only on the bottom
* move 'Clear filters' to side bar

#### Side bar with facets
* move side bar to right
* All time --> All dates in date filter
* 'Clear filters' --> 'Reset all filters' in side bar
* tool-tips go up instead of to the right since the side bar moved
* selected type looks more similar to the other filters

#### Search results
* title is at the very top of each result
* show only year for date published
* remove "filter links" from search results so only things that have detail pages are clickable
* when the description is truncated it won't cut words in half
* remove space between ellipsis and truncated description
* tags only have an outline
* moved date published with the other dates
* publisher is displayed with date published
* background is white

#### Entire page
* links and buttons get darker when hovered over
* background color is a very light blueish gray

## Side effects

Can't click on things in search results to filter by them.


## Ticket

https://openscience.atlassian.net/browse/SHARE-634
