### PR TITLE
[SHARE-606][Improvement] Expose share support email in footer

### DIFF
--- a/app/components/cos-footer/template.hbs
+++ b/app/components/cos-footer/template.hbs
@@ -3,7 +3,7 @@
         <div class="footer row">
             <div class="col-sm-4 center-block">
                 <ul class="links"><h4>SHARE</h4>
-                    <li><a href="https://share.osf.io/api/v2/">API</a></li>
+                    <li><a href="mailto:share-support@osf.io">Contact</a></li>
                     <li><a href="https://github.com/CenterForOpenScience/SHARE">Backend Source Code</a></li>
                     <li><a href="https://github.com/CenterForOpenScience/ember-share">Frontend Source Code</a></li>
                     <li><a href="http://share-research.readthedocs.io/en/latest/index.html">Developer Docs</a></li>

--- a/app/components/registration-status/component.js
+++ b/app/components/registration-status/component.js
@@ -14,7 +14,7 @@ const STATUS_HELP = {
         return registration.sourceName + ' is now a source. Check it out!';
     },
     rejected: function(registration) {
-        return registration.sourceName + ' has been rejected as a source. Contact support@osf.io for additional information.';
+        return registration.sourceName + ' has been rejected as a source. Contact share-support@osf.io for additional information.';
     },
 };
 

--- a/app/router.js
+++ b/app/router.js
@@ -24,7 +24,6 @@ Router.map(function() {
     this.route('changes');
     this.route('discover');
     this.route('profile');
-    this.route('support');
     this.route('settings');
     this.route('sources');
     this.route('registration', function() {

--- a/app/templates/notfound.hbs
+++ b/app/templates/notfound.hbs
@@ -5,7 +5,7 @@
             <img height="20%" width="20%" style="display:block; margin-left:auto; margin-right:auto" src="assets/images/main_logo.png">
         </div>
         <h4 style="text-align: center">
-            The requested resource could not be found. If this should not have occurred and the issue persists, please report it to support@osf.io.
+            The requested resource could not be found. If this should not have occurred and the issue persists, please report it to share-support@osf.io.
         </h4>
     </div>
 </div>

--- a/app/templates/registration/form.hbs
+++ b/app/templates/registration/form.hbs
@@ -251,7 +251,7 @@
                                     <div class="row">
                                         <span class="col-xs-12 text-danger">
                                             There was an error submitting your form. If this should not have occurred
-                                            and the issue persists, please report it to support@osf.io.
+                                            and the issue persists, please report it to share-support@osf.io.
                                         </span>
                                     </div>
                                     <div class="well registration-db-errors">


### PR DESCRIPTION
## Purpose

Expose the share support email in footer and change `support@osf.io` to `share-support@osf.io`.

## Changes

* API --> Contact in footer since the API can be reached through the developer docs
* `support@osf.io` --> `share-support@osf.io`
* removed unused `support` route

![screen shot 2017-04-17 at 1 01 05 pm](https://cloud.githubusercontent.com/assets/7131985/25096513/81be40a0-236e-11e7-9250-b4801bcd364b.png)


## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/SHARE-606
