### PR TITLE
[SHARE-938][Improvement] Only display sources with data on sources page

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -6,7 +6,6 @@ import buildElasticCall from '../utils/build-elastic-call';
 import ENV from '../config/environment';
 import { getUniqueList, getSplitParams, encodeParams } from '../utils/elastic-query';
 
-const MAX_SOURCES = 500;
 let filterQueryParams = ['tags', 'sources', 'publishers', 'funders', 'institutions', 'organizations', 'language', 'contributors', 'type'];
 
 export default ApplicationController.extend({
@@ -112,7 +111,7 @@ export default ApplicationController.extend({
                 sources: {
                     cardinality: {
                         field: 'sources',
-                        precision_threshold: MAX_SOURCES
+                        precision_threshold: ENV.maxSources
                     }
                 }
             }
@@ -214,7 +213,7 @@ export default ApplicationController.extend({
             sources: {
                 terms: {
                     field: 'sources',
-                    size: MAX_SOURCES
+                    size: ENV.maxSources
                 }
             }
         };

--- a/app/routes/sources.js
+++ b/app/routes/sources.js
@@ -1,4 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+    actions: {
+        elasticDown() {
+            this.intermediateTransitionTo('elastic-down');
+            return false;
+        }
+    }
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -6,6 +6,7 @@ module.exports = function(environment) {
         environment: environment,
         baseURL: '/share/',
         creativeworkName: 'Not Categorized',
+        maxSources: 500,
         locationType: 'auto',
         EmberENV: {
             EXTEND_PROTOTYPES: {


### PR DESCRIPTION
## Purpose

The number of sources on the sources page differ from the number on the discover page.

## Changes

Filter API results based on an elastic aggregation.

## Side effects

Only sources with data will display on the sources page. On staging and locally there might be only a few sources listed.


## Ticket

https://openscience.atlassian.net/browse/SHARE-938
