### PR TITLE
[SHARE-1030][Improvement] Use current year for copyright in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 *`CenterForOpenScience/ember-share` releases are tied to `CenterForOpenScience/SHARE` releases. If there were no changes to `ember-share` in a release then it will not be listed in this changelog. [Release notes for CenterForOpenScience/SHARE](https://github.com/CenterForOpenScience/SHARE/blob/develop/CHANGELOG.md).*
 
+# [2.14.1] - 2018-01-12
+## Fixed
+* Copyright year in footer
+
 # [2.14.0] - 2018-01-10
 ## Removed
 * Source registration form
@@ -58,7 +62,7 @@
 * MathJax rendering
 * More sorting methods
 * Detail pages for Organizations and Institutions
-  * List of published/funded/related works 
+  * List of published/funded/related works
 
 ## Changed
 * Numbers now have commas

--- a/app/components/cos-footer/component.js
+++ b/app/components/cos-footer/component.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-
+    currentYear: Ember.computed(function() {
+        return new Date().getUTCFullYear();
+    }),
 });

--- a/app/components/cos-footer/template.hbs
+++ b/app/components/cos-footer/template.hbs
@@ -32,7 +32,7 @@
     <div class="row">
         <div class="col-xs-12 copyright">
             <p>
-                Copyright © 2011-2017
+                Copyright © 2011-{{currentYear}}
                 <a href="https://cos.io/">Center for Open Science</a>
                 |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a>


### PR DESCRIPTION
## Purpose

The copyright in the footer says 2017 when it should say 2018.

## Changes

**Before:**
![screen shot 2018-01-12 at 11 50 13 am](https://user-images.githubusercontent.com/7131985/34885799-1a6e1dd0-f78f-11e7-9335-661e8cae338f.png)

**After:**
![screen shot 2018-01-12 at 11 49 57 am](https://user-images.githubusercontent.com/7131985/34885803-20b1285e-f78f-11e7-8415-5b62f8a2cfc9.png)

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/SHARE-1030
