### PR TITLE
[SHARE-1083] Changing the external link uri to display full uri instead of just host

### DIFF
--- a/app/components/section-links/template.hbs
+++ b/app/components/section-links/template.hbs
@@ -1,3 +1,3 @@
 {{#inline-list items=data as |identifier|}}
-  <a href={{identifier.uri}}>{{identifier.host}}</a>
+  <a href={{identifier.uri}}>{{identifier.uri}}</a>
 {{/inline-list}}


### PR DESCRIPTION
## Purpose

DOI's and other links are currently hidden in the record level view for external links.Changing the external link uri to display full uri instead of just host

## Changes

Changed link label from identifier.host to identifier.uri

## Side effects

## Ticket
Related ticket needs to be created re:conversation with Lauren B
https://openscience.atlassian.net/browse/SHARE-1083
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SHARE-1234 -->
